### PR TITLE
Use runtime PORT for FastAPI service

### DIFF
--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -19,4 +19,4 @@ ENV PORT=8080 PYTHONUNBUFFERED=1
 EXPOSE 8080
 
 # Start the FastAPI app
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]


### PR DESCRIPTION
## Summary
- use `PORT` environment variable when starting FastAPI server in Dockerfile

## Testing
- `python -m py_compile services/backend/app/main.py`
- `docker build -t vision-backend-test services/backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad2b59e8483279172b150c11dc6c5