### PR TITLE
Implement NDVI GeoTIFF export

### DIFF
--- a/services/backend/app/api/export.py
+++ b/services/backend/app/api/export.py
@@ -1,21 +1,165 @@
-# Placeholder export endpoint code
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException
-from typing import List
-import zipfile, tempfile, os
+import io
+import zipfile
+from datetime import date, datetime, timedelta
+from typing import Iterator, Tuple
+import urllib.error
+import urllib.request
+
+import ee
+from ee.ee_exception import EEException
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import StreamingResponse
+
+from app.services.tiles import init_ee
+from app.utils.shapefile import shapefile_zip_to_geojson
+
 
 router = APIRouter()
 
+
+def _parse_iso_date(label: str, value: str) -> date:
+    try:
+        return datetime.fromisoformat(value).date()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{label} must be an ISO 8601 date (YYYY-MM-DD)."
+        ) from exc
+
+
+def _month_start(d: date) -> date:
+    return date(d.year, d.month, 1)
+
+
+def _next_month(d: date) -> date:
+    return (d.replace(day=28) + timedelta(days=4)).replace(day=1)
+
+
+def _iter_month_ranges(start: date, end: date) -> Iterator[Tuple[int, int, date, date]]:
+    current = _month_start(start)
+    last = _month_start(end)
+    end_exclusive = end + timedelta(days=1)
+
+    while current <= last:
+        following = _next_month(current)
+        period_start = max(start, current)
+        period_end = min(end_exclusive, following)
+        if period_start < period_end:
+            yield current.year, current.month, period_start, period_end
+        current = following
+
+
+def _collection_size(collection: ee.ImageCollection) -> int:
+    return int(collection.size().getInfo())
+
+
+def _download_bytes(url: str) -> bytes:
+    try:
+        with urllib.request.urlopen(url) as resp:
+            if resp.status != 200:
+                raise HTTPException(status_code=502, detail=f"Earth Engine download failed with status {resp.status}.")
+            return resp.read()
+    except urllib.error.URLError as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to download GeoTIFF: {exc.reason}") from exc
+
+
+def _extract_first_tif(zip_bytes: bytes) -> bytes:
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as archive:
+            tif_names = [name for name in archive.namelist() if name.lower().endswith(".tif")]
+            if not tif_names:
+                raise HTTPException(status_code=502, detail="Earth Engine download did not contain a GeoTIFF.")
+            return archive.read(tif_names[0])
+    except zipfile.BadZipFile as exc:
+        raise HTTPException(status_code=502, detail="Earth Engine response was not a valid ZIP archive.") from exc
+
+
+def _ndvi_image_for_range(geometry_geojson: dict, start_iso: str, end_iso: str) -> Tuple[ee.ImageCollection, ee.Image]:
+    geom = ee.Geometry(geometry_geojson)
+    collection = (
+        ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")
+        .filterBounds(geom)
+        .filterDate(start_iso, end_iso)
+        .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", 60))
+        .map(lambda img: img.addBands(img.normalizedDifference(["B8", "B4"]).rename("NDVI")))
+    )
+    image = collection.select("NDVI").mean().clip(geom)
+    image = image.updateMask(image.gte(0).And(image.lte(1)))
+    return collection, image
+
+
 @router.post("/export")
-async def export_geotiffs(years: List[int] = Form(...), file: UploadFile = File(...)):
-    # Save uploaded file temporarily
-    tmp_dir = tempfile.mkdtemp()
-    input_path = os.path.join(tmp_dir, file.filename)
-    with open(input_path, "wb") as f:
-        f.write(await file.read())
+async def export_geotiffs(
+    start_date: str = Form(...),
+    end_date: str = Form(...),
+    file: UploadFile = File(..., description="Shapefile ZIP archive"),
+):
+    filename = (file.filename or "").lower()
+    if not filename.endswith(".zip"):
+        raise HTTPException(status_code=415, detail="Upload must be a shapefile ZIP archive (.zip).")
 
-    # Placeholder logic: just return an empty ZIP
-    zip_path = os.path.join(tmp_dir, "output.zip")
-    with zipfile.ZipFile(zip_path, "w") as zipf:
-        zipf.writestr("README.txt", "GeoTIFF export coming soon.")
+    start = _parse_iso_date("start_date", start_date)
+    end = _parse_iso_date("end_date", end_date)
+    if start > end:
+        raise HTTPException(status_code=400, detail="start_date must be on or before end_date.")
 
-    return {"ok": True, "zip_file": zip_path}
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Uploaded shapefile ZIP is empty.")
+
+    try:
+        geometry = shapefile_zip_to_geojson(content)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Failed to parse shapefile ZIP: {exc}") from exc
+
+    try:
+        init_ee()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to initialize Earth Engine: {exc}") from exc
+
+    output_buffer = io.BytesIO()
+    months_written = 0
+
+    with zipfile.ZipFile(output_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as combined_zip:
+        for year, month, period_start, period_end in _iter_month_ranges(start, end):
+            start_iso = period_start.isoformat()
+            end_iso = period_end.isoformat()
+
+            try:
+                collection, image = _ndvi_image_for_range(geometry, start_iso, end_iso)
+            except EEException as exc:
+                raise HTTPException(status_code=502, detail=f"Failed to build NDVI image for {year}-{month:02d}: {exc}") from exc
+
+            size = await run_in_threadpool(_collection_size, collection)
+            if size == 0:
+                raise HTTPException(status_code=404, detail=f"No imagery available for {year}-{month:02d}.")
+
+            try:
+                url = image.getDownloadURL(
+                    {
+                        "scale": 10,
+                        "region": geometry,
+                        "filePerBand": False,
+                        "format": "GEO_TIFF",
+                    }
+                )
+            except EEException as exc:
+                raise HTTPException(status_code=502, detail=f"Failed to create download URL for {year}-{month:02d}: {exc}") from exc
+
+            zip_bytes = await run_in_threadpool(_download_bytes, url)
+            tif_bytes = _extract_first_tif(zip_bytes)
+
+            output_name = f"ndvi_{year}_{month:02d}.tif"
+            combined_zip.writestr(output_name, tif_bytes)
+            months_written += 1
+
+    if months_written == 0:
+        raise HTTPException(status_code=404, detail="No months found within the requested date range.")
+
+    output_buffer.seek(0)
+    disposition = f'attachment; filename="ndvi_{start.isoformat()}_{end.isoformat()}.zip"'
+    headers = {"Content-Disposition": disposition}
+    return StreamingResponse(output_buffer, media_type="application/zip", headers=headers)

--- a/services/backend/app/utils/shapefile.py
+++ b/services/backend/app/utils/shapefile.py
@@ -1,0 +1,64 @@
+import io
+import os
+import tempfile
+import zipfile
+from typing import List
+
+import shapefile  # pyshp
+from fastapi import HTTPException
+from shapely.geometry import MultiPolygon, Polygon, mapping, shape
+from shapely.ops import unary_union
+
+
+def as_multipolygon(geoms: List[Polygon | MultiPolygon]) -> MultiPolygon:
+    polys: List[Polygon] = []
+    for geom in geoms:
+        if isinstance(geom, Polygon):
+            polys.append(geom)
+        elif isinstance(geom, MultiPolygon):
+            polys.extend(list(geom.geoms))
+    if not polys:
+        raise HTTPException(status_code=400, detail="No polygon features found.")
+    merged = unary_union(polys)
+    if isinstance(merged, Polygon):
+        return MultiPolygon([merged])
+    if isinstance(merged, MultiPolygon):
+        return merged
+    raise HTTPException(status_code=400, detail="Could not merge polygons.")
+
+
+def shapefile_zip_to_geojson(file_bytes: bytes) -> dict:
+    """Convert a shapefile ZIP archive to a GeoJSON MultiPolygon."""
+
+    with tempfile.TemporaryDirectory() as td:
+        try:
+            with zipfile.ZipFile(io.BytesIO(file_bytes), "r") as zf:
+                zf.extractall(td)
+        except zipfile.BadZipFile as exc:
+            raise HTTPException(status_code=400, detail="Uploaded file is not a valid ZIP archive.") from exc
+
+        shp_path = None
+        for name in os.listdir(td):
+            if name.lower().endswith(".shp"):
+                shp_path = os.path.join(td, name)
+                break
+
+        if not shp_path:
+            raise HTTPException(status_code=400, detail="ZIP must contain a .shp file.")
+
+        try:
+            reader = shapefile.Reader(shp_path)
+        except shapefile.ShapefileException as exc:
+            raise HTTPException(status_code=400, detail=f"Could not read shapefile: {exc}") from exc
+
+        geoms: List[Polygon | MultiPolygon] = []
+        for shp in reader.shapes():
+            try:
+                geom = shape(shp.__geo_interface__)
+            except Exception:
+                continue
+            if isinstance(geom, (Polygon, MultiPolygon)):
+                geoms.append(geom)
+
+        multipolygon = as_multipolygon(geoms)
+        return mapping(multipolygon)


### PR DESCRIPTION
### **User description**
## Summary
- add reusable shapefile parsing helpers and reuse them in the field upload endpoint
- implement the /export handler to validate the requested range, render monthly NDVI, and return GeoTIFFs in a zip stream

## Testing
- python -m compileall services/backend/app

------
https://chatgpt.com/codex/tasks/task_e_68cbec611fb083279f3571dbde28b509


___

### **PR Type**
Enhancement


___

### **Description**
- Implement complete NDVI GeoTIFF export functionality

- Add reusable shapefile parsing utilities

- Replace placeholder export endpoint with full implementation

- Add date range validation and monthly NDVI processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shapefile ZIP Upload"] --> B["Parse Shapefile"]
  B --> C["Validate Date Range"]
  C --> D["Initialize Earth Engine"]
  D --> E["Process Monthly NDVI"]
  E --> F["Download GeoTIFFs"]
  F --> G["Create ZIP Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.py</strong><dd><code>Complete NDVI GeoTIFF export implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/export.py

<ul><li>Replace placeholder export endpoint with full NDVI GeoTIFF <br>implementation<br> <li> Add date parsing, validation, and monthly range iteration utilities<br> <li> Implement Earth Engine integration for NDVI calculation and download<br> <li> Add streaming ZIP response with proper error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/4/files#diff-5e2d28a7e848b401191a00d5496480010316038f29a07a93e44dca190ef2a30b">+161/-17</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fields_upload.py</strong><dd><code>Refactor to use shared shapefile utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/fields_upload.py

<ul><li>Remove duplicate shapefile parsing functions<br> <li> Import and use shared utilities from <code>app.utils.shapefile</code><br> <li> Clean up imports and reduce code duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/4/files#diff-9cc432dd005a4b00946788d2b920fe4db2e35c2f89e8ef032e60aa39fb478cee">+5/-49</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shapefile.py</strong><dd><code>Add reusable shapefile parsing utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/utils/shapefile.py

<ul><li>Create new utility module for shapefile processing<br> <li> Extract <code>as_multipolygon</code> and <code>shapefile_zip_to_geojson</code> functions<br> <li> Add proper error handling for ZIP and shapefile parsing<br> <li> Make functions reusable across multiple endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/4/files#diff-eb999ce1d0bfb852cf62fcedf32f985066c2681ab2fc7ff9c745907ba732bad9">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

