### PR TITLE
Refactor area helpers to reuse equal-area projection

### DIFF
--- a/services/backend/app/utils/geometry.py
+++ b/services/backend/app/utils/geometry.py
@@ -1,0 +1,22 @@
+"""Geometry helpers shared across API endpoints."""
+from __future__ import annotations
+
+from shapely.geometry import shape
+from shapely.ops import transform as shp_transform
+from shapely.validation import make_valid
+from pyproj import Transformer
+
+# Australia Albers (equal-area). Matches the projection used for field areas.
+_EQUAL_AREA_TRANSFORMER = Transformer.from_crs("EPSG:4326", "EPSG:3577", always_xy=True)
+
+
+def area_m2(geojson_geom: dict) -> float:
+    """Return the area of a GeoJSON geometry in square metres using an equal-area CRS."""
+    geom = make_valid(shape(geojson_geom))
+    reproj = shp_transform(lambda x, y, z=None: _EQUAL_AREA_TRANSFORMER.transform(x, y), geom)
+    return float(reproj.area)
+
+
+def area_ha(geojson_geom: dict) -> float:
+    """Return the area of a GeoJSON geometry in hectares."""
+    return area_m2(geojson_geom) / 10000.0


### PR DESCRIPTION
### **User description**
## Summary
- extract a shared geometry helper that computes area in square metres/hectares using the existing EPSG:3577 projection
- reuse the helper in both the standard field creation and upload flows so hectares stay consistent across APIs

## Testing
- PYTHONPATH=services/backend pytest


------
https://chatgpt.com/codex/tasks/task_e_68cbfbc4b2288327884f3c1f5beee215


___

### **PR Type**
Enhancement


___

### **Description**
- Extract shared geometry area calculation helper functions

- Standardize area computation using EPSG:3577 projection

- Fix inconsistent projection usage between API endpoints

- Consolidate duplicate area calculation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fields.py"] --> C["geometry.py"]
  B["fields_upload.py"] --> C["geometry.py"]
  C --> D["area_m2()"]
  C --> E["area_ha()"]
  D --> F["EPSG:3577 projection"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields.py</strong><dd><code>Remove duplicate area calculation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/fields.py

<ul><li>Remove duplicate area calculation function <code>_area_m2()</code><br> <li> Import <code>area_m2</code> from shared geometry utils<br> <li> Update variable naming from <code>area_m2</code> to <code>area_sq_m</code><br> <li> Remove shapely and pyproj imports</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/9/files#diff-90a66d6fd33a50a0cc62992257725e6d8e52abd7d75798a7786a95d33d06a5a4">+3/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>geometry.py</strong><dd><code>Add shared geometry calculation utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/utils/geometry.py

<ul><li>Create new shared geometry utilities module<br> <li> Add <code>area_m2()</code> function using EPSG:3577 equal-area projection<br> <li> Add <code>area_ha()</code> function for hectare calculations<br> <li> Define shared transformer for consistent projections</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/9/files#diff-267b6c79e3b6df5a8247877356f55267a063b4ee735772468c4e1d526c488482">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fields_upload.py</strong><dd><code>Replace incorrect projection with shared helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/fields_upload.py

<ul><li>Remove duplicate area calculation function <code>_area_ha()</code><br> <li> Import <code>area_ha</code> from shared geometry utils<br> <li> Fix incorrect EPSG:3857 projection to use shared helper<br> <li> Remove shapely validation and pyproj imports</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/9/files#diff-9cc432dd005a4b00946788d2b920fe4db2e35c2f89e8ef032e60aa39fb478cee">+2/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

