### PR TITLE
Compute export API URL relative to UI page

### DIFF
--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -165,6 +165,12 @@ def export_ui():
       const form = document.getElementById('export-form');
       const status = document.getElementById('status');
 
+      const { origin, pathname } = window.location;
+      const trimmedPath = pathname.endsWith('/') && pathname !== '/' ? pathname.slice(0, -1) : pathname;
+      const basePath = trimmedPath.replace(/\/[^/]*$/, '/') || '/';
+      const apiUrl = new URL(`${basePath}api/export/export`, origin);
+      form.setAttribute('action', apiUrl.toString());
+
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
         status.textContent = 'Uploading shapefile and starting export…';
@@ -193,7 +199,7 @@ def export_ui():
         const headers = apiKey ? { 'x-api-key': apiKey } : {};
 
         try {
-          const response = await fetch('/api/export/export', {
+          const response = await fetch(apiUrl, {
             method: 'POST',
             headers,
             body: formData,


### PR DESCRIPTION
## Summary
- compute the export API endpoint URL relative to the UI page so it works behind path prefixes
- set the form action to the computed endpoint for consistent fallback when JS is disabled

## Testing
- python -m compileall services/backend/app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6f848b1883278bb8075ff79554b2