### PR TITLE
Align NDVI collection default with Copernicus dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # Vision Backend (Template)
 
 A Cloud Run–ready FastAPI backend template for NDVI/indices via Google Earth Engine.
- 
+
+
+## NDVI monthly endpoint
+
+The `/api/ndvi/monthly` route computes monthly NDVI statistics for a supplied GeoJSON geometry
+and date range. When the `collection` field is omitted it now defaults to the harmonized Sentinel-2
+surface reflectance dataset `COPERNICUS/S2_SR_HARMONIZED`, aligning with the rest of the
+application.
+
+Example request payload:
+
+```json
+{
+  "geometry": {"type": "Point", "coordinates": [0, 0]},
+  "start": "2023-01-01",
+  "end": "2023-12-31"
+}
+```
+
+This payload succeeds without specifying `collection` or `scale`, relying on the defaults.
+
  

--- a/services/backend/app/api/routes.py
+++ b/services/backend/app/api/routes.py
@@ -29,7 +29,7 @@ class NDVIRequest(BaseModel):
     geometry: dict
     start: str
     end: str
-    collection: str = "SENTINEL/2_SR_HARMONIZED"
+    collection: str = "COPERNICUS/S2_SR_HARMONIZED"
     scale: int = 10
 
 # NDVI monthly endpoint (simplified for testing)

--- a/services/backend/tests/test_ndvi_monthly.py
+++ b/services/backend/tests/test_ndvi_monthly.py
@@ -1,0 +1,112 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from app.api import routes
+
+
+class FakeValue:
+    def __init__(self, val):
+        self._val = val
+
+    def getInfo(self):
+        return self._val
+
+
+class FakeRegionResult:
+    def __init__(self, month):
+        self._month = month
+
+    def get(self, key):
+        return FakeValue(self._month / 100)
+
+
+class FakeImage:
+    def __init__(self, month):
+        self._month = month
+
+    def select(self, band):
+        return self
+
+    def reduceRegion(self, *args, **kwargs):
+        return FakeRegionResult(self._month)
+
+
+class FakeFilteredCollection:
+    def __init__(self, month):
+        self._month = month
+
+    def mean(self):
+        return FakeImage(self._month)
+
+
+class FakeMappedCollection:
+    def __init__(self, parent):
+        self._parent = parent
+
+    def filter(self, month):
+        return FakeFilteredCollection(month)
+
+
+class FakeImageCollection:
+    def __init__(self, name):
+        self.name = name
+        self.geom = None
+        self.start = None
+        self.end = None
+
+    def filterBounds(self, geom):
+        self.geom = geom
+        return self
+
+    def filterDate(self, start, end):
+        self.start = start
+        self.end = end
+        return self
+
+    def map(self, func):
+        return FakeMappedCollection(self)
+
+
+class FakeSequence(list):
+    def __init__(self, start, end):
+        super().__init__(range(start, end + 1))
+
+    def getInfo(self):
+        return list(self)
+
+
+def test_ndvi_monthly_defaults(monkeypatch):
+    captured = {}
+
+    def fake_image_collection(name):
+        captured["collection"] = name
+        return FakeImageCollection(name)
+
+    fake_ee = SimpleNamespace(
+        ImageCollection=fake_image_collection,
+        Geometry=lambda geom: geom,
+        Filter=SimpleNamespace(calendarRange=lambda start, end, unit: start),
+        List=SimpleNamespace(sequence=lambda start, end: FakeSequence(start, end)),
+        Reducer=SimpleNamespace(mean=lambda: "mean"),
+    )
+
+    monkeypatch.setattr(routes, "ee", fake_ee)
+    monkeypatch.setattr(routes, "init_ee", lambda: None)
+
+    request = routes.NDVIRequest(
+        geometry={"type": "Point", "coordinates": [0, 0]},
+        start="2023-01-01",
+        end="2023-12-31",
+    )
+
+    data = routes.ndvi_monthly(request)
+
+    assert data["ok"] is True
+    assert len(data["data"]) == 12
+    assert data["data"][0] == {"month": 1, "ndvi": 0.01}
+    assert captured["collection"] == "COPERNICUS/S2_SR_HARMONIZED"


### PR DESCRIPTION
### **User description**
## Summary
- switch the NDVI request schema default collection to COPERNICUS/S2_SR_HARMONIZED
- document the updated default and provide an example payload for the monthly NDVI endpoint
- add a regression test that exercises the monthly NDVI handler with default parameters via light Earth Engine stubs

## Testing
- pytest services/backend/tests/test_ndvi_monthly.py

------
https://chatgpt.com/codex/tasks/task_e_68ce3a407d3c83278b665985579b8292


___

### **PR Type**
Enhancement


___

### **Description**
- Update NDVI collection default to COPERNICUS/S2_SR_HARMONIZED

- Add comprehensive regression test with Earth Engine stubs

- Document updated default and provide example payload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NDVIRequest Schema"] --> B["Default Collection Updated"]
  B --> C["COPERNICUS/S2_SR_HARMONIZED"]
  D["Test Suite"] --> E["Earth Engine Stubs"]
  E --> F["Monthly NDVI Handler"]
  G["Documentation"] --> H["Example Payload"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.py</strong><dd><code>Update NDVI request default collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/routes.py

<ul><li>Changed default collection from <code>SENTINEL/2_SR_HARMONIZED</code> to <br><code>COPERNICUS/S2_SR_HARMONIZED</code></ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/13/files#diff-e8eb815ac45054bf20f3be6311286ac9ef38320dcad700c96d2afecb358481de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ndvi_monthly.py</strong><dd><code>Add NDVI monthly endpoint regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_ndvi_monthly.py

<ul><li>Added comprehensive test file with Earth Engine mocking infrastructure<br> <li> Created fake classes to simulate EE ImageCollection, Image, and <br>filtering operations<br> <li> Implemented test to verify default collection parameter usage<br> <li> Added validation for monthly NDVI computation results</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/13/files#diff-781429c2a0a35ab809e153171d398dcc19cc973c7219e468d9ca9bdff5c7d630">+112/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document NDVI endpoint defaults and usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added documentation section for NDVI monthly endpoint<br> <li> Documented the new default collection value<br> <li> Provided example JSON request payload<br> <li> Explained default parameter behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/13/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

