### PR TITLE
Allow negative NDVI values in exports and tiles

### DIFF
--- a/services/backend/app/api/export.py
+++ b/services/backend/app/api/export.py
@@ -101,7 +101,7 @@ def _ndvi_image_for_range(geometry_geojson: dict, start_iso: str, end_iso: str) 
         .map(lambda img: img.addBands(img.normalizedDifference(["B8", "B4"]).rename("NDVI")))
     )
     image = collection.select("NDVI").mean().clip(geom)
-    image = image.updateMask(image.gte(0).And(image.lte(1)))
+    image = image.clamp(-1, 1)
     return collection, image
 
 

--- a/services/backend/tests/test_ndvi_negative.py
+++ b/services/backend/tests/test_ndvi_negative.py
@@ -1,0 +1,141 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from app.api import export
+from app.services import tiles
+
+
+class FakeNDVIImage:
+    def __init__(self, value: float):
+        self.value = value
+        self.name = None
+
+    def rename(self, name: str):
+        self.name = name
+        return self
+
+
+class FakeImage:
+    def __init__(self, ndvi_value: float):
+        self._raw_ndvi = ndvi_value
+        self.ndvi_value = None
+
+    def normalizedDifference(self, _bands):
+        return FakeNDVIImage(self._raw_ndvi)
+
+    def addBands(self, ndvi_img):
+        self.ndvi_value = getattr(ndvi_img, "value", None)
+        return self
+
+
+class FakeMeanImage:
+    def __init__(self, value: float):
+        self.value = value
+        self.clamped_to = None
+        self.clipped_geom = None
+
+    def clip(self, geom):
+        self.clipped_geom = geom
+        return self
+
+    def clamp(self, low, high):
+        self.clamped_to = (low, high)
+        if self.value is None:
+            return self
+        if self.value < low:
+            self.value = low
+        elif self.value > high:
+            self.value = high
+        return self
+
+
+class FakeImageCollection:
+    def __init__(self, name: str, context: dict):
+        self.name = name
+        self.context = context
+        self.geom = None
+        self.start = None
+        self.end = None
+        self.filters = []
+        self.images = [FakeImage(val) for val in context["values"]]
+
+    def filterBounds(self, geom):
+        self.geom = geom
+        return self
+
+    def filterDate(self, start, end):
+        self.start = start
+        self.end = end
+        return self
+
+    def filter(self, filt):
+        self.filters.append(filt)
+        return self
+
+    def map(self, func):
+        self.images = [func(img) for img in self.images]
+        return self
+
+    def select(self, _band):
+        return self
+
+    def mean(self):
+        values = [img.ndvi_value if img.ndvi_value is not None else img._raw_ndvi for img in self.images]
+        mean_val = sum(values) / len(values) if values else None
+        return FakeMeanImage(mean_val)
+
+
+def _setup_fake_ee(monkeypatch, module, values):
+    context = {"values": list(values)}
+
+    def fake_image_collection(name):
+        context_copy = {"values": list(context["values"])}
+        return FakeImageCollection(name, context_copy)
+
+    fake_filter = SimpleNamespace(lt=lambda *args, **kwargs: ("lt", args, kwargs))
+    fake_ee = SimpleNamespace(
+        ImageCollection=fake_image_collection,
+        Geometry=lambda geom: geom,
+        Filter=fake_filter,
+    )
+
+    monkeypatch.setattr(module, "ee", fake_ee)
+
+    return context
+
+
+def test_export_ndvi_range_preserves_negatives(monkeypatch):
+    context = _setup_fake_ee(monkeypatch, export, [-0.6, -0.2])
+
+    _, image = export._ndvi_image_for_range({"type": "Point", "coordinates": [0, 0]}, "2024-01-01", "2024-02-01")
+
+    assert isinstance(image, FakeMeanImage)
+    assert image.clamped_to == (-1, 1)
+    assert image.value == pytest.approx(-0.4)
+
+    # Updating context should not affect the already computed image
+    context["values"] = [-0.1, 0.2]
+    assert image.value == pytest.approx(-0.4)
+
+
+def test_tile_ndvi_images_allow_negative_values(monkeypatch):
+    context = _setup_fake_ee(monkeypatch, tiles, [-0.8, -0.4])
+
+    annual = tiles.ndvi_annual_image({"type": "Polygon", "coordinates": []}, 2021)
+    assert isinstance(annual, FakeMeanImage)
+    assert annual.clamped_to == (-1, 1)
+    assert annual.value == pytest.approx(-0.6)
+
+    context["values"] = [-0.7, 0.1]
+    month = tiles.ndvi_month_image({"type": "Polygon", "coordinates": []}, 2021, 5)
+    assert isinstance(month, FakeMeanImage)
+    assert month.clamped_to == (-1, 1)
+    assert month.value == pytest.approx(-0.3)


### PR DESCRIPTION
### **User description**
## Summary
- clamp exported NDVI images to the full [-1, 1] range instead of masking out negatives
- update tile helpers to retain negative NDVI values and widen the default visualization range
- add unit tests with fake Earth Engine images to confirm negative NDVI survives export and tile paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce49b8c92c8327ac2630c9d746f760


___

### **PR Type**
Enhancement


___

### **Description**
- Replace NDVI masking with clamping to preserve negative values

- Update tile visualization range from [0, 0.8] to [-1, 1]

- Add comprehensive unit tests for negative NDVI handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NDVI Calculation"] --> B["Old: Mask negatives"]
  A --> C["New: Clamp to [-1,1]"]
  C --> D["Export API"]
  C --> E["Tile Service"]
  C --> F["Unit Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.py</strong><dd><code>Replace NDVI masking with clamping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/export.py

<ul><li>Replace <code>updateMask</code> with <code>clamp(-1, 1)</code> to preserve negative NDVI values</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/14/files#diff-5e2d28a7e848b401191a00d5496480010316038f29a07a93e44dca190ef2a30b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tiles.py</strong><dd><code>Update tile NDVI handling and visualization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/tiles.py

<ul><li>Replace <code>updateMask</code> with <code>clamp(-1, 1)</code> in annual and monthly NDVI <br>functions<br> <li> Update default visualization range from [0, 0.8] to [-1, 1]<br> <li> Update comments to reflect negative value preservation</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/14/files#diff-c420ded67b271247fc247ac9932da9692949bb7608835f8ce2e3e4dedd2499e6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ndvi_negative.py</strong><dd><code>Add negative NDVI unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_ndvi_negative.py

<ul><li>Add comprehensive test suite with fake Earth Engine classes<br> <li> Test export API preserves negative NDVI values<br> <li> Test tile service handles negative values correctly<br> <li> Verify clamping behavior with mock objects</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/14/files#diff-c83edcbce25051119f70bba8ef38dc1f1d531e0e140863a6857a4fcafe3f94c0">+141/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

