### PR TITLE
Handle shapefile CRS conversion to WGS84

### DIFF
--- a/services/backend/tests/test_shapefile_utils.py
+++ b/services/backend/tests/test_shapefile_utils.py
@@ -1,0 +1,83 @@
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+import shapefile  # pyshp
+from fastapi import HTTPException
+from pyproj import CRS, Transformer
+from shapely.geometry import shape
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from app.utils.shapefile import shapefile_zip_to_geojson
+
+
+def _write_polygon_shapefile(base_path: Path, coords):
+    writer = shapefile.Writer(str(base_path))
+    writer.field("id", "N")
+    writer.poly([coords])
+    writer.record(1)
+    writer.close()
+
+
+def test_shapefile_zip_to_geojson_transforms_epsg3857_to_wgs84(tmp_path):
+    wgs84_coords = [
+        (-122.0, 37.0),
+        (-122.0, 37.0005),
+        (-121.9995, 37.0005),
+        (-121.9995, 37.0),
+        (-122.0, 37.0),
+    ]
+
+    transformer = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
+    projected_coords = [transformer.transform(lon, lat) for lon, lat in wgs84_coords]
+
+    base_path = tmp_path / "test_polygon"
+    _write_polygon_shapefile(base_path, projected_coords)
+
+    prj_path = base_path.with_suffix(".prj")
+    prj_path.write_text(CRS.from_epsg(3857).to_wkt())
+
+    zip_path = tmp_path / "polygon.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for ext in ("shp", "shx", "dbf", "prj"):
+            zf.write(str(base_path.with_suffix(f".{ext}")), arcname=f"test_polygon.{ext}")
+
+    geojson = shapefile_zip_to_geojson(zip_path.read_bytes())
+
+    geom = shape(geojson)
+    assert geom.geom_type == "MultiPolygon"
+    polygon = list(geom.geoms)[0]
+    converted_coords = list(polygon.exterior.coords)
+
+    assert len(converted_coords) == len(wgs84_coords)
+    for (expected_lon, expected_lat), (lon, lat) in zip(wgs84_coords, converted_coords):
+        assert lon == pytest.approx(expected_lon, abs=1e-6)
+        assert lat == pytest.approx(expected_lat, abs=1e-6)
+
+
+def test_shapefile_zip_to_geojson_missing_prj_raises(tmp_path):
+    wgs84_coords = [
+        (-122.0, 37.0),
+        (-122.0, 37.0005),
+        (-121.9995, 37.0005),
+        (-121.9995, 37.0),
+        (-122.0, 37.0),
+    ]
+
+    base_path = tmp_path / "test_polygon_missing_prj"
+    _write_polygon_shapefile(base_path, wgs84_coords)
+
+    zip_path = tmp_path / "polygon_missing_prj.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for ext in ("shp", "shx", "dbf"):
+            zf.write(str(base_path.with_suffix(f".{ext}")), arcname=f"test_polygon_missing_prj.{ext}")
+
+    with pytest.raises(HTTPException) as excinfo:
+        shapefile_zip_to_geojson(zip_path.read_bytes())
+
+    assert excinfo.value.status_code == 400
+    assert ".prj" in excinfo.value.detail


### PR DESCRIPTION
### **User description**
## Summary
- read shapefile projection from the accompanying .prj file and transform polygons into WGS84
- raise clear errors when the CRS metadata is missing or invalid
- add tests covering EPSG:3857 conversion and enforcement of .prj files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce58e8a39c83279e9f12ce1a05c456


___

### **PR Type**
Enhancement


___

### **Description**
- Add CRS conversion from shapefile projection to WGS84

- Enforce presence of .prj file for coordinate system metadata

- Transform geometries using pyproj when source CRS differs from WGS84

- Add comprehensive tests for EPSG:3857 conversion and error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shapefile ZIP"] --> B["Extract .prj file"]
  B --> C["Parse CRS from WKT"]
  C --> D["Compare with WGS84"]
  D --> E["Transform coordinates"]
  E --> F["GeoJSON output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shapefile.py</strong><dd><code>Implement CRS conversion and validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/utils/shapefile.py

<ul><li>Add pyproj imports for CRS handling and coordinate transformation<br> <li> Read and validate .prj file for coordinate reference system metadata<br> <li> Create transformer when source CRS differs from WGS84 (EPSG:4326)<br> <li> Transform geometry coordinates before adding to collection</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/15/files#diff-eb999ce1d0bfb852cf62fcedf32f985066c2681ab2fc7ff9c745907ba732bad9">+40/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_shapefile_utils.py</strong><dd><code>Add comprehensive CRS conversion tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_shapefile_utils.py

<ul><li>Add test for EPSG:3857 to WGS84 coordinate transformation<br> <li> Test missing .prj file error handling with HTTPException<br> <li> Create helper function for writing polygon shapefiles<br> <li> Verify coordinate accuracy after transformation</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/15/files#diff-cc282cf66321dcbc6bc0b6c8186a1b90f49681d15a39419ebc2f9298022a6e38">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

