### PR TITLE
Add optional EPSG override for shapefile uploads

### DIFF
--- a/services/backend/app/api/export.py
+++ b/services/backend/app/api/export.py
@@ -110,6 +110,10 @@ async def export_geotiffs(
     start_date: str = Form(...),
     end_date: str = Form(...),
     file: UploadFile = File(..., description="Shapefile ZIP archive"),
+    source_epsg: Optional[str] = Form(
+        None,
+        description="EPSG code of the uploaded shapefile when no .prj is included.",
+    ),
 ):
     filename = (file.filename or "").lower()
     if not filename.endswith(".zip"):
@@ -124,8 +128,10 @@ async def export_geotiffs(
     if not content:
         raise HTTPException(status_code=400, detail="Uploaded shapefile ZIP is empty.")
 
+    epsg_code = source_epsg.strip() if source_epsg else None
+
     try:
-        geometry = shapefile_zip_to_geojson(content)
+        geometry = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
     except HTTPException:
         raise
     except Exception as exc:

--- a/services/backend/app/api/fields_upload.py
+++ b/services/backend/app/api/fields_upload.py
@@ -51,14 +51,19 @@ def _kml_or_kmz_to_geojson(file_bytes: bytes, is_kmz: bool) -> dict:
 @router.post("/upload")
 async def upload_field(
     file: UploadFile = File(..., description="Shapefile ZIP (.zip), KML (.kml) or KMZ (.kmz)"),
-    name: Optional[str] = Form(None)
+    name: Optional[str] = Form(None),
+    source_epsg: Optional[str] = Form(
+        None,
+        description="EPSG code of the uploaded shapefile when no .prj is included.",
+    ),
 ):
     fname = (file.filename or "").lower()
     content = await file.read()
+    epsg_code = source_epsg.strip() if source_epsg else None
 
     try:
         if fname.endswith(".zip"):
-            geom = shapefile_zip_to_geojson(content)
+            geom = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
         elif fname.endswith(".kml"):
             geom = _kml_or_kmz_to_geojson(content, is_kmz=False)
         elif fname.endswith(".kmz"):


### PR DESCRIPTION
## Summary
- allow shapefile conversion helper to accept an optional EPSG code when a .prj file is missing
- expose the EPSG override on the field upload and NDVI export endpoints
- add coverage for the EPSG override and the error case when no CRS information is provided

## Testing
- pytest services/backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68ce65cb8e848327983279c0ab6f7d70