### PR TITLE
Default shapefile CRS to WGS84 when missing

### DIFF
--- a/services/backend/app/api/fields_upload.py
+++ b/services/backend/app/api/fields_upload.py
@@ -61,9 +61,11 @@ async def upload_field(
     content = await file.read()
     epsg_code = source_epsg.strip() if source_epsg else None
 
+    defaulted_crs = False
+
     try:
         if fname.endswith(".zip"):
-            geom = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
+            geom, defaulted_crs = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
         elif fname.endswith(".kml"):
             geom = _kml_or_kmz_to_geojson(content, is_kmz=False)
         elif fname.endswith(".kmz"):
@@ -110,4 +112,10 @@ async def upload_field(
     except Exception:
         pass
 
-    return {"ok": True, **meta}
+    response = {"ok": True, **meta}
+    if defaulted_crs:
+        response["crs_warning"] = (
+            "No CRS information supplied; defaulted to EPSG:4326 (WGS84)."
+        )
+
+    return response


### PR DESCRIPTION
## Summary
- default the shapefile conversion utility to EPSG:4326 when no CRS metadata is provided
- surface CRS default warnings in the field upload and export endpoints
- update shapefile utility tests for the new default behavior and verify explicit EPSG codes still work

## Testing
- pytest services/backend/tests/test_shapefile_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68ce68f9df708327befc3363ab04edf1