### PR TITLE
Enforce CRS metadata requirement for shapefile uploads

### DIFF
--- a/services/backend/app/api/export.py
+++ b/services/backend/app/api/export.py
@@ -1,5 +1,4 @@
 import io
-import logging
 import zipfile
 from datetime import date, datetime, timedelta
 from typing import Iterator, Optional, Tuple
@@ -113,7 +112,7 @@ async def export_geotiffs(
     file: UploadFile = File(..., description="Shapefile ZIP archive"),
     source_epsg: Optional[str] = Form(
         None,
-        description="EPSG code of the uploaded shapefile when no .prj is included.",
+        description="EPSG code of the uploaded shapefile (required when no .prj is included).",
     ),
 ):
     filename = (file.filename or "").lower()
@@ -132,17 +131,11 @@ async def export_geotiffs(
     epsg_code = source_epsg.strip() if source_epsg else None
 
     try:
-        geometry, defaulted_crs = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
+        geometry = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
     except HTTPException:
         raise
     except Exception as exc:
         raise HTTPException(status_code=400, detail=f"Failed to parse shapefile ZIP: {exc}") from exc
-
-    if defaulted_crs:
-        # Export endpoint returns binary data, so we log instead of modifying the response.
-        logging.getLogger(__name__).warning(
-            "Shapefile missing CRS; defaulted to EPSG:4326 (WGS84) for export request."
-        )
 
     try:
         init_ee()

--- a/services/backend/app/api/fields_upload.py
+++ b/services/backend/app/api/fields_upload.py
@@ -54,18 +54,16 @@ async def upload_field(
     name: Optional[str] = Form(None),
     source_epsg: Optional[str] = Form(
         None,
-        description="EPSG code of the uploaded shapefile when no .prj is included.",
+        description="EPSG code of the uploaded shapefile (required when no .prj is included).",
     ),
 ):
     fname = (file.filename or "").lower()
     content = await file.read()
     epsg_code = source_epsg.strip() if source_epsg else None
 
-    defaulted_crs = False
-
     try:
         if fname.endswith(".zip"):
-            geom, defaulted_crs = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
+            geom = shapefile_zip_to_geojson(content, source_epsg=epsg_code)
         elif fname.endswith(".kml"):
             geom = _kml_or_kmz_to_geojson(content, is_kmz=False)
         elif fname.endswith(".kmz"):
@@ -112,10 +110,4 @@ async def upload_field(
     except Exception:
         pass
 
-    response = {"ok": True, **meta}
-    if defaulted_crs:
-        response["crs_warning"] = (
-            "No CRS information supplied; defaulted to EPSG:4326 (WGS84)."
-        )
-
-    return response
+    return {"ok": True, **meta}


### PR DESCRIPTION
## Summary
- stop guessing EPSG:4326 in shapefile_zip_to_geojson and require explicit CRS metadata
- update field upload and export handlers to surface the new validation and clean up their responses
- refresh shapefile utility tests to expect the HTTP 400 error and keep coverage for explicit EPSG overrides

## Testing
- pytest services/backend/tests/test_shapefile_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ce7e2d424483279e2d13a67f4a8190