### PR TITLE
Resample NDVI exports with bilinear interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,11 @@ Example request payload:
 
 This payload succeeds without specifying `collection` or `scale`, relying on the defaults.
 
+
+## NDVI GeoTIFF exports
+
+The `/api/export` endpoint now resamples the NDVI band with bilinear interpolation at 10 m
+resolution before clipping exports to the submitted geometry. This avoids nearest-neighbour
+artifacts when comparing the GeoTIFFs against vector boundaries.
+
  

--- a/services/backend/app/api/export.py
+++ b/services/backend/app/api/export.py
@@ -100,7 +100,13 @@ def _ndvi_image_for_range(geometry_geojson: dict, start_iso: str, end_iso: str) 
         .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", 60))
         .map(lambda img: img.addBands(img.normalizedDifference(["B8", "B4"]).rename("NDVI")))
     )
-    image = collection.select("NDVI").mean().clip(geom)
+    ndvi_band = (
+        collection.select("NDVI")
+        .mean()
+        .resample("bilinear")
+        .reproject("EPSG:4326", None, 10)
+    )
+    image = ndvi_band.clip(geom)
     image = image.clamp(-1, 1)
     return collection, image
 

--- a/services/backend/app/services/tiles.py
+++ b/services/backend/app/services/tiles.py
@@ -37,7 +37,13 @@ def ndvi_annual_image(geometry_geojson: dict, year: int) -> ee.Image:
     geom = ee.Geometry(geometry_geojson)
     start, end = f"{year}-01-01", f"{year}-12-31"
     coll = _s2_ndvi_collection(geom, start, end)
-    img = coll.select("NDVI").mean().clip(geom)
+    ndvi_band = (
+        coll.select("NDVI")
+        .mean()
+        .resample("bilinear")
+        .reproject("EPSG:4326", None, 10)
+    )
+    img = ndvi_band.clip(geom)
     # Clamp NDVI values to the theoretical range so negatives are preserved
     return img.clamp(-1, 1)
 
@@ -50,7 +56,13 @@ def ndvi_month_image(geometry_geojson: dict, year: int, month: int) -> ee.Image:
     else:
         end = f"{year}-{month+1:02d}-01"
     coll = _s2_ndvi_collection(geom, start, end)
-    img = coll.select("NDVI").mean().clip(geom)
+    ndvi_band = (
+        coll.select("NDVI")
+        .mean()
+        .resample("bilinear")
+        .reproject("EPSG:4326", None, 10)
+    )
+    img = ndvi_band.clip(geom)
     return img.clamp(-1, 1)
 
 # ---------- Tile URL factory ----------

--- a/services/backend/tests/test_ndvi_negative.py
+++ b/services/backend/tests/test_ndvi_negative.py
@@ -41,6 +41,16 @@ class FakeMeanImage:
         self.value = value
         self.clamped_to = None
         self.clipped_geom = None
+        self.resample_method = None
+        self.reproject_args = None
+
+    def resample(self, method: str):
+        self.resample_method = method
+        return self
+
+    def reproject(self, crs: str, transform, scale: int):
+        self.reproject_args = (crs, transform, scale)
+        return self
 
     def clip(self, geom):
         self.clipped_geom = geom
@@ -120,6 +130,8 @@ def test_export_ndvi_range_preserves_negatives(monkeypatch):
     assert isinstance(image, FakeMeanImage)
     assert image.clamped_to == (-1, 1)
     assert image.value == pytest.approx(-0.4)
+    assert image.resample_method == "bilinear"
+    assert image.reproject_args == ("EPSG:4326", None, 10)
 
     # Updating context should not affect the already computed image
     context["values"] = [-0.1, 0.2]
@@ -133,9 +145,13 @@ def test_tile_ndvi_images_allow_negative_values(monkeypatch):
     assert isinstance(annual, FakeMeanImage)
     assert annual.clamped_to == (-1, 1)
     assert annual.value == pytest.approx(-0.6)
+    assert annual.resample_method == "bilinear"
+    assert annual.reproject_args == ("EPSG:4326", None, 10)
 
     context["values"] = [-0.7, 0.1]
     month = tiles.ndvi_month_image({"type": "Polygon", "coordinates": []}, 2021, 5)
     assert isinstance(month, FakeMeanImage)
     assert month.clamped_to == (-1, 1)
     assert month.value == pytest.approx(-0.3)
+    assert month.resample_method == "bilinear"
+    assert month.reproject_args == ("EPSG:4326", None, 10)


### PR DESCRIPTION
## Summary
- resample NDVI imagery with bilinear interpolation at 10 m before clipping for exports and tiles
- update NDVI tests to record and assert the new resample/reproject behaviour
- document that NDVI GeoTIFF exports now use bilinear sampling

## Testing
- pytest services/backend/tests/test_ndvi_negative.py

------
https://chatgpt.com/codex/tasks/task_e_68ce7f86235483279828a6ca0dbb9d5e