### PR TITLE
Ensure NDVI exports use metre-based reprojection

### DIFF
--- a/services/backend/app/api/export.py
+++ b/services/backend/app/api/export.py
@@ -104,6 +104,7 @@ def _ndvi_image_for_range(geometry_geojson: dict, start_iso: str, end_iso: str) 
         collection.select("NDVI")
         .mean()
         .resample("bilinear")
+        .reproject("EPSG:3857", None, 10)
     )
     image = ndvi_band.clip(geom)
     image = image.clamp(-1, 1)
@@ -167,6 +168,7 @@ async def export_geotiffs(
             try:
                 url = image.getDownloadURL(
                     {
+                        "crs": "EPSG:3857",
                         "scale": 10,
                         "region": geometry,
                         "filePerBand": False,

--- a/services/backend/tests/test_ndvi_negative.py
+++ b/services/backend/tests/test_ndvi_negative.py
@@ -131,7 +131,7 @@ def test_export_ndvi_range_preserves_negatives(monkeypatch):
     assert image.clamped_to == (-1, 1)
     assert image.value == pytest.approx(-0.4)
     assert image.resample_method == "bilinear"
-    assert image.reproject_args is None
+    assert image.reproject_args == ("EPSG:3857", None, 10)
     assert image.clipped_geom == {"type": "Point", "coordinates": [0, 0]}
 
     # Updating context should not affect the already computed image


### PR DESCRIPTION
### **User description**
## Summary
- reproject the exported NDVI composite to EPSG:3857 at a 10 m nominal scale
- request GeoTIFF downloads with the matching CRS so Earth Engine interprets the scale in metres
- update NDVI tests to capture the new reprojection behaviour

## Testing
- pytest services/backend/tests/test_ndvi_negative.py

------
https://chatgpt.com/codex/tasks/task_e_68ce8793010083278c93282fde967e9b


___

### **PR Type**
Enhancement


___

### **Description**
- Reproject NDVI exports to EPSG:3857 at 10m scale

- Add CRS parameter to GeoTIFF download requests

- Update test assertions for new reprojection behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NDVI Image Processing"] --> B["Reproject to EPSG:3857"]
  B --> C["10m Scale Resolution"]
  C --> D["GeoTIFF Export with CRS"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.py</strong><dd><code>Add EPSG:3857 reprojection to NDVI processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/export.py

<ul><li>Add <code>.reproject("EPSG:3857", None, 10)</code> to NDVI band processing<br> <li> Include <code>"crs": "EPSG:3857"</code> in GeoTIFF download parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/22/files#diff-5e2d28a7e848b401191a00d5496480010316038f29a07a93e44dca190ef2a30b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ndvi_negative.py</strong><dd><code>Update test for new reprojection behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_ndvi_negative.py

<ul><li>Update test assertion to expect reprojection arguments<br> <li> Change from <code>None</code> to <code>("EPSG:3857", None, 10)</code> for reproject_args</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/22/files#diff-c83edcbce25051119f70bba8ef38dc1f1d531e0e140863a6857a4fcafe3f94c0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

