### PR TITLE
Handle empty monthly NDVI collections

### DIFF
--- a/services/backend/app/api/routes.py
+++ b/services/backend/app/api/routes.py
@@ -63,7 +63,12 @@ def ndvi_monthly(req: NDVIRequest):
         months = ee.List.sequence(1, 12)
         results = []
         for m in months.getInfo():
-            monthly = with_ndvi.filter(ee.Filter.calendarRange(m, m, "month")).mean().select("NDVI")
+            monthly_coll = with_ndvi.filter(ee.Filter.calendarRange(m, m, "month"))
+            if monthly_coll.size().eq(0).getInfo():
+                results.append({"month": int(m), "ndvi": None})
+                continue
+
+            monthly = monthly_coll.mean().select("NDVI")
             value = monthly.reduceRegion(
                 reducer=ee.Reducer.mean(),
                 geometry=geom,

--- a/services/backend/app/services/ndvi.py
+++ b/services/backend/app/services/ndvi.py
@@ -60,7 +60,12 @@ def compute_monthly_ndvi(
     out = []
     sampling_kwargs = reduce_region_sampling(scale=scale, crs=crs)
     for m in months.getInfo():
-        mean = coll.filter(ee.Filter.calendarRange(m, m, "month")).mean().select("NDVI")
+        monthly_coll = coll.filter(ee.Filter.calendarRange(m, m, "month"))
+        if monthly_coll.size().eq(0).getInfo():
+            out.append({"month": int(m), "ndvi": None})
+            continue
+
+        mean = monthly_coll.mean().select("NDVI")
         val = mean.reduceRegion(
             reducer=ee.Reducer.mean(),
             geometry=geom,


### PR DESCRIPTION
## Summary
- guard the NDVI monthly API route against empty monthly image collections and return `None` for missing imagery
- apply the same empty-collection handling to the compute_monthly_ndvi service path so cached results match
- extend the NDVI monthly test suite with helpers and scenarios covering months that have no images

## Testing
- pytest services/backend/tests/test_ndvi_monthly.py

------
https://chatgpt.com/codex/tasks/task_e_68ce8d40d04c8327a7a0fe6e262f364b