### PR TITLE
Default shapefile CRS fallback to EPSG:4326

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ artifacts when comparing the GeoTIFFs against vector boundaries.
 
 
 ## Updates
+- 2025-09-24: Defaulted shapefile uploads without CRS metadata to EPSG:4326 with client-facing warnings, updated shapefile util tests for the new fallback, ran `pytest services/backend/tests/test_shapefile_utils.py -q` (pass), noted that `ruff check .` and `ruff format --check .` still flag longstanding import/formatting issues in legacy modules, and `mypy services/backend` continues to fail because project dependencies like shapely/pyshp/google-cloud lack bundled typing stubs.
 - 2025-09-23: Added CRS detector hints for projection-less shapefile uploads, appended the human-readable guidance to HTTP 400 responses and logs, extended tests to assert the hint surfaces when metadata is missing, ran `pytest services/backend/tests -q` (pass), and `ruff check .` / `ruff format --check .` continue to report longstanding import-grouping and formatting violations in legacy modules.
 - 2025-09-22: Required shapefile uploads without projection metadata to supply a .prj or source_epsg, refreshed heuristic warnings to
   direct clients toward sharing CRS details, documented the new HTTP 400 expectation in tests, ran `pytest` (pass), and noted that

--- a/services/backend/app/utils/shapefile.py
+++ b/services/backend/app/utils/shapefile.py
@@ -368,14 +368,16 @@ def shapefile_zip_to_geojson(
                     warnings.append(heuristic_warning)
                     logger.warning(heuristic_warning)
             else:
+                source_crs = CRS.from_epsg(4326)
                 message = (
-                    "Missing CRS (.prj) and no source_epsg provided. Include the .prj in the ZIP or pass source_epsg=<EPSG code>."
+                    "Missing CRS (.prj) and no source_epsg provided. Defaulting to EPSG:4326 (WGS84)."
+                    " Include the .prj in the ZIP or pass source_epsg=<EPSG code> to avoid this assumption."
                 )
                 suggestion = detect_coordinate_system_suggestion(shapes)
                 if suggestion is not None:
                     message = f"{message} {suggestion.human_readable_hint}"
+                warnings.append(message)
                 logger.warning(message)
-                raise HTTPException(status_code=400, detail=message)
 
         target_crs = WGS84_CRS
         transformer: Transformer | None = None


### PR DESCRIPTION
### **User description**
## Summary
- default shapefile uploads lacking projection metadata to EPSG:4326 and emit a client-visible warning when heuristics cannot infer a CRS
- refresh the shapefile utility regression to cover the WGS84 fallback and ensure warnings are logged
- document the behavior change in the README updates log

## Testing
- ruff check . *(fails: existing multi-import and module-order violations in legacy files)*
- ruff format --check . *(fails: numerous pre-existing formatting issues across legacy modules)*
- pytest services/backend/tests/test_shapefile_utils.py -q
- mypy services/backend *(fails: missing third-party type stubs and unresolved app.* imports in legacy modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cf64f5ff388327b38c632ed5d1d9be


___

### **PR Type**
Enhancement


___

### **Description**
- Default shapefile uploads without CRS metadata to EPSG:4326

- Replace HTTP 400 error with warning message

- Update tests to verify fallback behavior

- Document behavior change in README


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shapefile Upload"] --> B["Missing CRS Check"]
  B --> C["Infer CRS Heuristics"]
  C --> D["CRS Found?"]
  D -->|No| E["Default to EPSG:4326"]
  D -->|Yes| F["Use Inferred CRS"]
  E --> G["Emit Warning"]
  F --> H["Process Shapefile"]
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shapefile.py</strong><dd><code>Implement CRS fallback to WGS84</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/utils/shapefile.py

<ul><li>Replace HTTP 400 exception with EPSG:4326 fallback<br> <li> Update warning message to indicate default assumption<br> <li> Add warning to warnings list for client visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/32/files#diff-eb999ce1d0bfb852cf62fcedf32f985066c2681ab2fc7ff9c745907ba732bad9">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_shapefile_utils.py</strong><dd><code>Update tests for CRS fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_shapefile_utils.py

<ul><li>Remove HTTPException import and exception testing<br> <li> Update test to verify successful processing with warnings<br> <li> Add coordinate validation for fallback behavior<br> <li> Verify warning message content and logging</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/32/files#diff-cc282cf66321dcbc6bc0b6c8186a1b90f49681d15a39419ebc2f9298022a6e38">+21/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document CRS fallback changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document new shapefile CRS fallback behavior<br> <li> Note test results and linting status<br> <li> Add entry to updates section with timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/32/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

