### PR TITLE
Restore shapefile WGS84 fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ artifacts when comparing the GeoTIFFs against vector boundaries.
 
 
 ## Updates
+- 2025-09-26: Restored the shapefile CRS fallback to EPSG:4326 when metadata is missing, logging a client warning about the assumption, updated shapefile utility tests, ran `pytest services/backend/tests/test_shapefile_utils.py -q` (pass); `ruff check .` / `ruff format --check .` still flag longstanding import/formatting issues, and `mypy services/backend` continues to fail because dependencies lack typing stubs.
 - 2025-09-25: Replaced the shapefile CRS fallback with an explicit HTTP 400 requiring projection metadata and updated the shapefile utility tests.
   Ran `pytest services/backend/tests/test_shapefile_utils.py -q` (pass), while `ruff check .` / `ruff format --check .` still surface longstanding import/formatting violations, and `mypy services/backend` continues to fail because core dependencies and legacy modules lack typing support.
 - 2025-09-24: Defaulted shapefile uploads without CRS metadata to EPSG:4326 with client-facing warnings, updated shapefile util tests for the new fallback, ran `pytest services/backend/tests/test_shapefile_utils.py -q` (pass), noted that `ruff check .` and `ruff format --check .` still flag longstanding import/formatting issues in legacy modules, and `mypy services/backend` continues to fail because project dependencies like shapely/pyshp/google-cloud lack bundled typing stubs.

--- a/services/backend/app/utils/shapefile.py
+++ b/services/backend/app/utils/shapefile.py
@@ -366,13 +366,13 @@ def shapefile_zip_to_geojson(
                     warnings.append(heuristic_warning)
                     logger.warning(heuristic_warning)
             else:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "Missing CRS (.prj) and no source_epsg provided. Include the .prj in the ZIP or pass "
-                        "source_epsg=<EPSG code>."
-                    ),
+                source_crs = WGS84_CRS
+                fallback_warning = (
+                    "Shapefile ZIP is missing projection information; defaulting to EPSG:4326 (WGS84) because no CRS metadata was provided."
+                    " Provide the .prj file in the ZIP or pass source_epsg=<EPSG code> to avoid this assumption."
                 )
+                warnings.append(fallback_warning)
+                logger.warning(fallback_warning)
 
         target_crs = WGS84_CRS
         transformer: Transformer | None = None


### PR DESCRIPTION
### **User description**
## Summary
- default shapefile uploads without CRS metadata to EPSG:4326 while surfacing a warning instead of rejecting the request
- refresh the shapefile utility test to expect the WGS84 fallback and clean up imports
- log the change in the repository README updates section

## Testing
- pytest
- ruff check . *(fails: existing import grouping violations)*
- ruff format --check . *(fails: existing formatting issues)*
- mypy services/backend *(fails: missing stubs and annotations in legacy modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6de0cb908327bce582321bddae7d


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restore WGS84 fallback for shapefiles missing CRS metadata

- Replace HTTP 400 error with warning and default to EPSG:4326

- Update tests to expect fallback behavior instead of exceptions

- Document change in README updates section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shapefile without CRS"] --> B["Check for .prj file"]
  B --> C["Missing CRS metadata"]
  C --> D["Default to EPSG:4326"]
  D --> E["Log warning message"]
  E --> F["Continue processing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shapefile.py</strong><dd><code>Replace CRS error with WGS84 fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/utils/shapefile.py

<ul><li>Replace HTTPException with WGS84 fallback when CRS is missing<br> <li> Add warning message about defaulting to EPSG:4326<br> <li> Log warning and append to warnings list</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/34/files#diff-eb999ce1d0bfb852cf62fcedf32f985066c2681ab2fc7ff9c745907ba732bad9">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_shapefile_utils.py</strong><dd><code>Update tests for CRS fallback behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_shapefile_utils.py

<ul><li>Remove HTTPException import and pytest.raises test<br> <li> Update test to expect successful processing with warnings<br> <li> Verify warning message content and geometry processing</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/34/files#diff-cc282cf66321dcbc6bc0b6c8186a1b90f49681d15a39419ebc2f9298022a6e38">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document shapefile CRS fallback change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add entry documenting shapefile CRS fallback restoration<br> <li> Note test results and ongoing linting/typing issues</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/34/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

