### PR TITLE
Handle dynamic NDVI month ranges and skip missing NDVI results

### DIFF
--- a/services/backend/tests/test_ndvi_monthly.py
+++ b/services/backend/tests/test_ndvi_monthly.py
@@ -110,3 +110,75 @@ def test_ndvi_monthly_defaults(monkeypatch):
     assert len(data["data"]) == 12
     assert data["data"][0] == {"month": 1, "ndvi": 0.01}
     assert captured["collection"] == "COPERNICUS/S2_SR_HARMONIZED"
+
+
+def test_ndvi_monthly_partial_year(monkeypatch):
+    captured_months = []
+
+    class PartialRegionResult:
+        def __init__(self, month):
+            self._month = month
+
+        def get(self, key):
+            if self._month == 4:
+                return None
+            return FakeValue(self._month / 100)
+
+    class PartialImage:
+        def __init__(self, month):
+            self._month = month
+
+        def select(self, band):
+            return self
+
+        def reduceRegion(self, *args, **kwargs):
+            return PartialRegionResult(self._month)
+
+    class PartialFilteredCollection:
+        def __init__(self, month):
+            self._month = month
+
+        def mean(self):
+            return PartialImage(self._month)
+
+    class PartialMappedCollection:
+        def filter(self, month):
+            captured_months.append(month)
+            return PartialFilteredCollection(month)
+
+    class PartialImageCollection:
+        def __init__(self, name):
+            self.name = name
+
+        def filterBounds(self, geom):
+            return self
+
+        def filterDate(self, start, end):
+            self.start = start
+            self.end = end
+            return self
+
+        def map(self, func):
+            return PartialMappedCollection()
+
+    fake_ee = SimpleNamespace(
+        ImageCollection=PartialImageCollection,
+        Geometry=lambda geom: geom,
+        Filter=SimpleNamespace(calendarRange=lambda start, end, unit: start),
+        Reducer=SimpleNamespace(mean=lambda: "mean"),
+    )
+
+    monkeypatch.setattr(routes, "ee", fake_ee)
+    monkeypatch.setattr(routes, "init_ee", lambda: None)
+
+    request = routes.NDVIRequest(
+        geometry={"type": "Point", "coordinates": [0, 0]},
+        start="2023-03-15",
+        end="2023-05-20",
+    )
+
+    data = routes.ndvi_monthly(request)
+
+    assert data["ok"] is True
+    assert [entry["month"] for entry in data["data"]] == [3, 5]
+    assert captured_months == [3, 4, 5]


### PR DESCRIPTION
## Summary
- derive the NDVI month iteration from the request start/end dates instead of a fixed 1–12 range
- skip monthly results when Earth Engine returns no NDVI value while preserving existing error handling
- add a regression test covering a partial-year NDVI query to ensure only requested months are processed

## Testing
- pytest services/backend/tests/test_ndvi_monthly.py

------
https://chatgpt.com/codex/tasks/task_e_68cf7f3f0ca48327802efe969ca00535