### PR TITLE
Harden shapefile ZIP extraction against path traversal

### DIFF
--- a/services/backend/tests/test_shapefile_utils.py
+++ b/services/backend/tests/test_shapefile_utils.py
@@ -1,0 +1,36 @@
+import io
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from app.utils.shapefile import shapefile_zip_to_geojson
+
+
+def test_malicious_zip_rejected():
+    unique_name = f"vision_backend_{uuid4().hex}.shp"
+    target_file = Path(tempfile.gettempdir()) / unique_name
+    if target_file.exists():
+        target_file.unlink()
+
+    malicious_member = target_file.as_posix()
+
+    with io.BytesIO() as buffer:
+        with zipfile.ZipFile(buffer, "w") as zf:
+            zf.writestr(malicious_member, b"dummy")
+        payload = buffer.getvalue()
+
+    with pytest.raises(HTTPException) as excinfo:
+        shapefile_zip_to_geojson(payload)
+
+    assert excinfo.value.status_code == 400
+    assert "unsafe" in excinfo.value.detail.lower()
+    assert not target_file.exists()


### PR DESCRIPTION
## Summary
- replace the shapefile ZIP extraction with a guarded routine that rejects absolute paths and parent traversals
- ensure extracted members are written only within the temporary directory using streamed copy
- add a unit test that feeds a malicious ZIP and verifies an HTTP 400 is raised without writing the payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf8012ac3083279ebbafa02a52bdb8