### PR TITLE
Generalize tile rendering with index metadata

### DIFF
--- a/services/backend/app/api/tiles.py
+++ b/services/backend/app/api/tiles.py
@@ -1,34 +1,128 @@
-from fastapi import APIRouter, HTTPException
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.services.indices import resolve_index
 from app.services.tiles import (
-    init_ee, load_field_geometry, ndvi_annual_image, ndvi_month_image, get_tile_template_for_image
+    get_tile_template_for_image,
+    index_annual_image,
+    index_month_image,
+    init_ee,
+    load_field_geometry,
+    resolve_clamp_range,
 )
 
 router = APIRouter()
 
+def _collect_overrides(
+    vis_min: float | None,
+    vis_max: float | None,
+    vis_palette: str | None,
+) -> Dict[str, Any] | None:
+    overrides: Dict[str, Any] = {}
+    if vis_min is not None:
+        overrides["min"] = vis_min
+    if vis_max is not None:
+        overrides["max"] = vis_max
+    if vis_palette is not None:
+        overrides["palette"] = vis_palette
+    return overrides or None
+
+
 @router.get("/tiles/ndvi/annual/{field_id}/{year}")
-def tiles_ndvi_annual(field_id: str, year: int):
+def tiles_ndvi_annual(
+    field_id: str,
+    year: int,
+    index: str = Query("ndvi"),
+    vis_min: float | None = Query(None),
+    vis_max: float | None = Query(None),
+    vis_palette: str | None = Query(None),
+):
+    overrides = _collect_overrides(vis_min, vis_max, vis_palette)
+
     try:
         init_ee()
         geom = load_field_geometry(field_id)
-        img = ndvi_annual_image(geom, year)
-        t = get_tile_template_for_image(img)
-        return {"ok": True, "field_id": field_id, "year": year, **t}
+        definition, params = resolve_index(index)
+        resolved_params = dict(params)
+        img = index_annual_image(
+            geom,
+            year,
+            definition=definition,
+            parameters=resolved_params,
+        )
+        clamp_range = resolve_clamp_range(definition, overrides)
+        if clamp_range is not None:
+            img = img.clamp(*clamp_range)
+        tile = get_tile_template_for_image(
+            img,
+            definition=definition,
+            vis_overrides=overrides,
+        )
+        return {
+            "ok": True,
+            "field_id": field_id,
+            "year": year,
+            "index": definition.code,
+            "band": definition.band_name,
+            "parameters": resolved_params,
+            "clamp_range": list(clamp_range) if clamp_range is not None else None,
+            **tile,
+        }
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Tile failed: {e}")
 
 @router.get("/tiles/ndvi/month/{field_id}/{year}/{month}")
-def tiles_ndvi_month(field_id: str, year: int, month: int):
+def tiles_ndvi_month(
+    field_id: str,
+    year: int,
+    month: int,
+    index: str = Query("ndvi"),
+    vis_min: float | None = Query(None),
+    vis_max: float | None = Query(None),
+    vis_palette: str | None = Query(None),
+):
     if month < 1 or month > 12:
         raise HTTPException(status_code=400, detail="month must be 1..12")
+    overrides = _collect_overrides(vis_min, vis_max, vis_palette)
     try:
         init_ee()
         geom = load_field_geometry(field_id)
-        img = ndvi_month_image(geom, year, month)
-        t = get_tile_template_for_image(img)
-        return {"ok": True, "field_id": field_id, "year": year, "month": month, **t}
+        definition, params = resolve_index(index)
+        resolved_params = dict(params)
+        img = index_month_image(
+            geom,
+            year,
+            month,
+            definition=definition,
+            parameters=resolved_params,
+        )
+        clamp_range = resolve_clamp_range(definition, overrides)
+        if clamp_range is not None:
+            img = img.clamp(*clamp_range)
+        tile = get_tile_template_for_image(
+            img,
+            definition=definition,
+            vis_overrides=overrides,
+        )
+        return {
+            "ok": True,
+            "field_id": field_id,
+            "year": year,
+            "month": month,
+            "index": definition.code,
+            "band": definition.band_name,
+            "parameters": resolved_params,
+            "clamp_range": list(clamp_range) if clamp_range is not None else None,
+            **tile,
+        }
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Tile failed: {e}")

--- a/services/backend/app/services/indices.py
+++ b/services/backend/app/services/indices.py
@@ -26,10 +26,19 @@ class IndexDefinition:
     band_name: str
     valid_range: Tuple[float, float] | None
     compute: IndexComputer
+    default_palette: Tuple[str, ...] | None = None
     parameter_builder: ParameterBuilder = field(default=_default_parameter_builder)
 
     def prepare_parameters(self, params: Mapping[str, Any] | None = None) -> Dict[str, Any]:
         return self.parameter_builder(params)
+
+    def default_visualization(self) -> Dict[str, Any]:
+        vis: Dict[str, Any] = {"bands": [self.band_name]}
+        if self.valid_range is not None:
+            vis["min"], vis["max"] = self.valid_range
+        if self.default_palette is not None:
+            vis["palette"] = list(self.default_palette)
+        return vis
 
 
 def _normalized_difference(band_pair: Tuple[str, str], name: str) -> IndexComputer:
@@ -74,24 +83,43 @@ def _compute_ndre(image: ee.Image, params: Mapping[str, Any]) -> ee.Image:
 SUPPORTED_INDICES: Tuple[str, ...] = ("ndvi", "evi", "gndvi", "ndre")
 
 
+DEFAULT_VEGETATION_PALETTE: Tuple[str, ...] = (
+    "440154",
+    "482173",
+    "433E85",
+    "38598C",
+    "2D708E",
+    "25858E",
+    "1E9B8A",
+    "2BB07F",
+    "51C56A",
+    "85D54A",
+    "C2DF23",
+    "FDE725",
+)
+
+
 INDEX_DEFINITIONS: Dict[str, IndexDefinition] = {
     "ndvi": IndexDefinition(
         code="ndvi",
         band_name="NDVI",
         valid_range=(-1.0, 1.0),
         compute=_normalized_difference(("B8", "B4"), "NDVI"),
+        default_palette=DEFAULT_VEGETATION_PALETTE,
     ),
     "evi": IndexDefinition(
         code="evi",
         band_name="EVI",
         valid_range=(-1.0, 1.0),
         compute=_compute_evi,
+        default_palette=DEFAULT_VEGETATION_PALETTE,
     ),
     "gndvi": IndexDefinition(
         code="gndvi",
         band_name="GNDVI",
         valid_range=(-1.0, 1.0),
         compute=_normalized_difference(("B8", "B3"), "GNDVI"),
+        default_palette=DEFAULT_VEGETATION_PALETTE,
     ),
     "ndre": IndexDefinition(
         code="ndre",
@@ -99,6 +127,7 @@ INDEX_DEFINITIONS: Dict[str, IndexDefinition] = {
         valid_range=(-1.0, 1.0),
         compute=_compute_ndre,
         parameter_builder=_prepare_ndre_parameters,
+        default_palette=DEFAULT_VEGETATION_PALETTE,
     ),
 }
 

--- a/services/backend/app/services/tiles.py
+++ b/services/backend/app/services/tiles.py
@@ -1,6 +1,12 @@
-import ee, os, json, pathlib
+import json
+import os
+import pathlib
+from typing import Any, Mapping
+
+import ee
 from ee import ServiceAccountCredentials
 from app.services.gcs import download_json, exists
+from app.services.indices import IndexDefinition, resolve_index
 
 # Reuse the same SA method you used for NDVI
 SA_EMAIL = os.getenv("EE_SERVICE_ACCOUNT", "ee-agri-worker@baradine-farm.iam.gserviceaccount.com")
@@ -23,52 +29,189 @@ def init_ee():
     creds = ServiceAccountCredentials(SA_EMAIL, _find_or_write_keyfile())
     ee.Initialize(credentials=creds, opt_url="https://earthengine.googleapis.com")
 
+DEFAULT_COLLECTION = "COPERNICUS/S2_SR_HARMONIZED"
+_CLOUD_COVER_THRESHOLD = 60
+
+
 # ---------- Image builders ----------
 
-def _s2_ndvi_collection(geom: ee.Geometry, start: str, end: str, collection: str = "COPERNICUS/S2_SR_HARMONIZED"):
-    coll = (ee.ImageCollection(collection)
-            .filterBounds(geom)
-            .filterDate(start, end)
-            .filter(ee.Filter.lt('CLOUDY_PIXEL_PERCENTAGE', 60))
-            .map(lambda img: img.addBands(img.normalizedDifference(["B8", "B4"]).rename("NDVI"))))
+def _s2_index_collection(
+    geom: ee.Geometry,
+    start: str,
+    end: str,
+    *,
+    definition: IndexDefinition,
+    parameters: Mapping[str, Any],
+    collection: str = DEFAULT_COLLECTION,
+) -> ee.ImageCollection:
+    """Return a Sentinel-2 image collection with the requested index band mapped."""
+
+    coll = (
+        ee.ImageCollection(collection)
+        .filterBounds(geom)
+        .filterDate(start, end)
+        .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", _CLOUD_COVER_THRESHOLD))
+        .map(lambda img: img.addBands(definition.compute(img, parameters)))
+    )
     return coll
 
-def ndvi_annual_image(geometry_geojson: dict, year: int) -> ee.Image:
+
+def _index_image_for_range(
+    geometry_geojson: dict,
+    start: str,
+    end: str,
+    *,
+    definition: IndexDefinition,
+    parameters: Mapping[str, Any],
+    collection: str = DEFAULT_COLLECTION,
+) -> ee.Image:
     geom = ee.Geometry(geometry_geojson)
+    coll = _s2_index_collection(
+        geom,
+        start,
+        end,
+        definition=definition,
+        parameters=parameters,
+        collection=collection,
+    )
+    img = coll.select(definition.band_name).mean().clip(geom)
+    if definition.valid_range is not None:
+        low, high = definition.valid_range
+        img = img.clamp(low, high)
+    return img
+
+
+def index_annual_image(
+    geometry_geojson: dict,
+    year: int,
+    *,
+    definition: IndexDefinition,
+    parameters: Mapping[str, Any],
+    collection: str = DEFAULT_COLLECTION,
+) -> ee.Image:
     start, end = f"{year}-01-01", f"{year}-12-31"
-    coll = _s2_ndvi_collection(geom, start, end)
-    img = coll.select("NDVI").mean().clip(geom)
-    # Clamp NDVI values to the theoretical range so negatives are preserved
-    return img.clamp(-1, 1)
+    return _index_image_for_range(
+        geometry_geojson,
+        start,
+        end,
+        definition=definition,
+        parameters=parameters,
+        collection=collection,
+    )
+
+
+def index_month_image(
+    geometry_geojson: dict,
+    year: int,
+    month: int,
+    *,
+    definition: IndexDefinition,
+    parameters: Mapping[str, Any],
+    collection: str = DEFAULT_COLLECTION,
+) -> ee.Image:
+    start = f"{year}-{month:02d}-01"
+    if month == 12:
+        end = f"{year + 1}-01-01"
+    else:
+        end = f"{year}-{month + 1:02d}-01"
+    return _index_image_for_range(
+        geometry_geojson,
+        start,
+        end,
+        definition=definition,
+        parameters=parameters,
+        collection=collection,
+    )
+
+
+def ndvi_annual_image(geometry_geojson: dict, year: int) -> ee.Image:
+    definition, params = resolve_index("ndvi")
+    return index_annual_image(
+        geometry_geojson,
+        year,
+        definition=definition,
+        parameters=params,
+    )
+
 
 def ndvi_month_image(geometry_geojson: dict, year: int, month: int) -> ee.Image:
-    geom = ee.Geometry(geometry_geojson)
-    start = f"{year}-{month:02d}-01"
-    # safe end-of-month: add 32 days and set to day 1 previous; simpler: next month start
-    if month == 12:
-        end = f"{year+1}-01-01"
-    else:
-        end = f"{year}-{month+1:02d}-01"
-    coll = _s2_ndvi_collection(geom, start, end)
-    img = coll.select("NDVI").mean().clip(geom)
-    return img.clamp(-1, 1)
+    definition, params = resolve_index("ndvi")
+    return index_month_image(
+        geometry_geojson,
+        year,
+        month,
+        definition=definition,
+        parameters=params,
+    )
+
 
 # ---------- Tile URL factory ----------
 
-DEFAULT_PALETTE = [
-    "440154","482173","433E85","38598C","2D708E","25858E","1E9B8A","2BB07F","51C56A","85D54A","C2DF23","FDE725"
-]  # viridis-ish hex (no '#')
+def _coerce_palette(value: Any) -> list[str]:
+    if isinstance(value, str):
+        items = [part.strip() for part in value.split(",") if part.strip()]
+    elif isinstance(value, (list, tuple)):
+        items = [str(part) for part in value if str(part)]
+    else:
+        raise TypeError("Palette override must be a string or sequence of strings.")
 
-def get_tile_template_for_image(img: ee.Image, vis: dict | None = None) -> dict:
-    """
-    Returns a dict containing {mapid, token, tile_url, vis} compatible with XYZ tile layers.
-    """
-    if vis is None:
-        vis = {"bands": ["NDVI"], "min": -1.0, "max": 1.0, "palette": DEFAULT_PALETTE}
-    mp = img.getMapId(vis)  # legacy-style, still supported by earthengine-api
-    # mp contains: {'mapid': ..., 'token': ..., 'tile_fetcher': ...}
-    tile_url = mp["tile_fetcher"].url_format  # e.g. https://earthengine.googleapis.com/map/{mapid}/{z}/{x}/{y}?token={token}
-    return {"mapid": mp["mapid"], "token": mp["token"], "tile_url": tile_url, "vis": vis}
+    if not items:
+        raise ValueError("Palette override must include at least one colour.")
+    return items
+
+
+def _build_visualization(
+    definition: IndexDefinition,
+    overrides: Mapping[str, Any] | None = None,
+) -> dict:
+    vis = definition.default_visualization()
+    if overrides:
+        vis = dict(vis)  # copy to avoid mutating default
+        if "min" in overrides and overrides["min"] is not None:
+            vis["min"] = float(overrides["min"])
+        if "max" in overrides and overrides["max"] is not None:
+            vis["max"] = float(overrides["max"])
+        if "palette" in overrides and overrides["palette"] is not None:
+            vis["palette"] = _coerce_palette(overrides["palette"])
+    return vis
+
+
+def resolve_clamp_range(
+    definition: IndexDefinition,
+    overrides: Mapping[str, Any] | None = None,
+) -> tuple[float, float] | None:
+    base = definition.valid_range
+    min_val = base[0] if base is not None else None
+    max_val = base[1] if base is not None else None
+    if overrides:
+        override_min = overrides.get("min")
+        override_max = overrides.get("max")
+        if override_min is not None:
+            min_val = float(override_min)
+        if override_max is not None:
+            max_val = float(override_max)
+    if min_val is None or max_val is None:
+        return None
+    return float(min_val), float(max_val)
+
+
+def get_tile_template_for_image(
+    img: ee.Image,
+    *,
+    definition: IndexDefinition,
+    vis_overrides: Mapping[str, Any] | None = None,
+) -> dict:
+    """Return map tile metadata for the provided index image."""
+
+    vis = _build_visualization(definition, vis_overrides)
+    mp = img.getMapId(vis)
+    tile_url = mp["tile_fetcher"].url_format
+    return {
+        "mapid": mp["mapid"],
+        "token": mp["token"],
+        "tile_url": tile_url,
+        "vis": vis,
+    }
 
 def load_field_geometry(field_id: str) -> dict:
     path = f"fields/{field_id}/field.geojson"

--- a/services/backend/tests/fake_ee.py
+++ b/services/backend/tests/fake_ee.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+
+class FakeIndexBand:
+    def __init__(self, value: float, context: dict[str, Any]):
+        self.value = value
+        self.name: str | None = None
+        self._context = context
+
+    def rename(self, name: str):
+        self.name = name
+        log = self._context.setdefault("log", {})
+        log.setdefault("renamed_bands", []).append(name)
+        return self
+
+
+class FakeImage:
+    def __init__(self, raw_value: float, context: dict[str, Any]):
+        self._raw_value = raw_value
+        self._context = context
+        self.index_value: float | None = None
+
+    def normalizedDifference(self, bands: Iterable[str]):
+        log = self._context.setdefault("log", {})
+        log.setdefault("normalized_difference_bands", []).append(tuple(bands))
+        return FakeIndexBand(self._raw_value, self._context)
+
+    def addBands(self, band_image: FakeIndexBand):
+        self.index_value = getattr(band_image, "value", None)
+        log = self._context.setdefault("log", {})
+        log.setdefault("added_bands", []).append(getattr(band_image, "name", None))
+        return self
+
+    def select(self, band: str):
+        log = self._context.setdefault("log", {})
+        log.setdefault("selected_bands", []).append(band)
+        return self
+
+
+class FakeMeanImage:
+    def __init__(self, value: float | None):
+        self.value = value
+        self.clamped_to: tuple[float, float] | None = None
+        self.clipped_geom: Any = None
+        self.requested_vis: dict[str, Any] | None = None
+
+    def clip(self, geom: Any):
+        self.clipped_geom = geom
+        return self
+
+    def clamp(self, low: float, high: float):
+        self.clamped_to = (low, high)
+        if self.value is None:
+            return self
+        if self.value < low:
+            self.value = low
+        elif self.value > high:
+            self.value = high
+        return self
+
+    def getMapId(self, vis: dict[str, Any]):
+        self.requested_vis = vis
+        return {
+            "mapid": "fake-mapid",
+            "token": "fake-token",
+            "tile_fetcher": SimpleNamespace(url_format="https://fake/{z}/{x}/{y}"),
+        }
+
+
+class FakeImageCollection:
+    def __init__(self, name: str, context: dict[str, Any]):
+        self.name = name
+        self.context = context
+        self.geom: Any = None
+        self.start: str | None = None
+        self.end: str | None = None
+        self.filters: list[Any] = []
+        values = context.get("values", [])
+        self.images = [FakeImage(val, context) for val in values]
+        context.setdefault("log", {}).setdefault("collections", []).append(name)
+
+    def filterBounds(self, geom: Any):
+        self.geom = geom
+        self.context.setdefault("log", {})["geometry"] = geom
+        return self
+
+    def filterDate(self, start: str, end: str):
+        self.start = start
+        self.end = end
+        self.context.setdefault("log", {})["date_range"] = (start, end)
+        return self
+
+    def filter(self, filt: Any):
+        self.filters.append(filt)
+        self.context.setdefault("log", {}).setdefault("filters", []).append(filt)
+        return self
+
+    def map(self, func):
+        self.images = [func(img) for img in self.images]
+        return self
+
+    def select(self, band: str):
+        self.context.setdefault("log", {}).setdefault("selected_bands", []).append(band)
+        return self
+
+    def mean(self):
+        values = [
+            img.index_value if img.index_value is not None else img._raw_value
+            for img in self.images
+        ]
+        mean_val = sum(values) / len(values) if values else None
+        return FakeMeanImage(mean_val)
+
+
+def setup_fake_ee(monkeypatch, module, values: Iterable[float]):
+    context: dict[str, Any] = {"values": list(values), "log": {}}
+
+    def fake_image_collection(name: str):
+        context_copy = {"values": list(context["values"]), "log": context["log"]}
+        return FakeImageCollection(name, context_copy)
+
+    fake_filter = SimpleNamespace(
+        lt=lambda *args, **kwargs: ("lt", args, kwargs),
+        calendarRange=lambda start, _end, _unit: start,
+    )
+
+    fake_ee = SimpleNamespace(
+        ImageCollection=fake_image_collection,
+        Geometry=lambda geom: geom,
+        Filter=fake_filter,
+    )
+
+    monkeypatch.setattr(module, "ee", fake_ee)
+
+    return context
+
+
+__all__ = [
+    "FakeImage",
+    "FakeImageCollection",
+    "FakeIndexBand",
+    "FakeMeanImage",
+    "setup_fake_ee",
+]

--- a/services/backend/tests/test_ndvi_negative.py
+++ b/services/backend/tests/test_ndvi_negative.py
@@ -1,8 +1,13 @@
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
+
+TEST_DIR = Path(__file__).resolve().parent
+if str(TEST_DIR) not in sys.path:
+    sys.path.append(str(TEST_DIR))
+
+from fake_ee import FakeMeanImage, setup_fake_ee
 
 
 BACKEND_DIR = Path(__file__).resolve().parents[1]
@@ -13,107 +18,8 @@ from app.api import export
 from app.services import tiles
 
 
-class FakeNDVIImage:
-    def __init__(self, value: float):
-        self.value = value
-        self.name = None
-
-    def rename(self, name: str):
-        self.name = name
-        return self
-
-
-class FakeImage:
-    def __init__(self, ndvi_value: float):
-        self._raw_ndvi = ndvi_value
-        self.ndvi_value = None
-
-    def normalizedDifference(self, _bands):
-        return FakeNDVIImage(self._raw_ndvi)
-
-    def addBands(self, ndvi_img):
-        self.ndvi_value = getattr(ndvi_img, "value", None)
-        return self
-
-
-class FakeMeanImage:
-    def __init__(self, value: float):
-        self.value = value
-        self.clamped_to = None
-        self.clipped_geom = None
-
-    def clip(self, geom):
-        self.clipped_geom = geom
-        return self
-
-    def clamp(self, low, high):
-        self.clamped_to = (low, high)
-        if self.value is None:
-            return self
-        if self.value < low:
-            self.value = low
-        elif self.value > high:
-            self.value = high
-        return self
-
-
-class FakeImageCollection:
-    def __init__(self, name: str, context: dict):
-        self.name = name
-        self.context = context
-        self.geom = None
-        self.start = None
-        self.end = None
-        self.filters = []
-        self.images = [FakeImage(val) for val in context["values"]]
-
-    def filterBounds(self, geom):
-        self.geom = geom
-        return self
-
-    def filterDate(self, start, end):
-        self.start = start
-        self.end = end
-        return self
-
-    def filter(self, filt):
-        self.filters.append(filt)
-        return self
-
-    def map(self, func):
-        self.images = [func(img) for img in self.images]
-        return self
-
-    def select(self, _band):
-        return self
-
-    def mean(self):
-        values = [img.ndvi_value if img.ndvi_value is not None else img._raw_ndvi for img in self.images]
-        mean_val = sum(values) / len(values) if values else None
-        return FakeMeanImage(mean_val)
-
-
-def _setup_fake_ee(monkeypatch, module, values):
-    context = {"values": list(values)}
-
-    def fake_image_collection(name):
-        context_copy = {"values": list(context["values"])}
-        return FakeImageCollection(name, context_copy)
-
-    fake_filter = SimpleNamespace(lt=lambda *args, **kwargs: ("lt", args, kwargs))
-    fake_ee = SimpleNamespace(
-        ImageCollection=fake_image_collection,
-        Geometry=lambda geom: geom,
-        Filter=fake_filter,
-    )
-
-    monkeypatch.setattr(module, "ee", fake_ee)
-
-    return context
-
-
 def test_export_ndvi_range_preserves_negatives(monkeypatch):
-    context = _setup_fake_ee(monkeypatch, export, [-0.6, -0.2])
+    context = setup_fake_ee(monkeypatch, export, [-0.6, -0.2])
 
     _, image = export._ndvi_image_for_range({"type": "Point", "coordinates": [0, 0]}, "2024-01-01", "2024-02-01")
 
@@ -127,7 +33,7 @@ def test_export_ndvi_range_preserves_negatives(monkeypatch):
 
 
 def test_tile_ndvi_images_allow_negative_values(monkeypatch):
-    context = _setup_fake_ee(monkeypatch, tiles, [-0.8, -0.4])
+    context = setup_fake_ee(monkeypatch, tiles, [-0.8, -0.4])
 
     annual = tiles.ndvi_annual_image({"type": "Polygon", "coordinates": []}, 2021)
     assert isinstance(annual, FakeMeanImage)

--- a/services/backend/tests/test_tiles_indices.py
+++ b/services/backend/tests/test_tiles_indices.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+TEST_DIR = Path(__file__).resolve().parent
+if str(TEST_DIR) not in sys.path:
+    sys.path.append(str(TEST_DIR))
+
+from fake_ee import FakeMeanImage, setup_fake_ee
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from app.services import tiles  # noqa: E402  pylint: disable=wrong-import-position
+from app.services.indices import resolve_index  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_gndvi_images_and_metadata(monkeypatch):
+    context = setup_fake_ee(monkeypatch, tiles, [0.4, 0.8])
+
+    definition, params = resolve_index("gndvi")
+
+    annual = tiles.index_annual_image(
+        {"type": "Polygon", "coordinates": []},
+        2020,
+        definition=definition,
+        parameters=params,
+    )
+
+    assert isinstance(annual, FakeMeanImage)
+    assert annual.clamped_to == (-1.0, 1.0)
+    assert annual.value == pytest.approx(0.6)
+
+    bands = context["log"].get("normalized_difference_bands", [])
+    assert bands, "Expected normalized difference bands to be recorded"
+    assert set(bands) == {("B8", "B3")}
+
+    context["values"] = [1.5, 2.0]
+    month = tiles.index_month_image(
+        {"type": "Polygon", "coordinates": []},
+        2020,
+        6,
+        definition=definition,
+        parameters=params,
+    )
+
+    assert isinstance(month, FakeMeanImage)
+    assert month.clamped_to == (-1.0, 1.0)
+    assert month.value == pytest.approx(1.0)
+
+    tile = tiles.get_tile_template_for_image(month, definition=definition)
+    assert tile["vis"]["bands"] == [definition.band_name]
+    assert tile["vis"]["min"] == pytest.approx(definition.valid_range[0])
+    assert tile["vis"]["max"] == pytest.approx(definition.valid_range[1])
+    assert tile["vis"]["palette"] == list(definition.default_palette)
+
+
+def test_index_tile_visualization_overrides(monkeypatch):
+    setup_fake_ee(monkeypatch, tiles, [0.1, 0.5])
+    definition, params = resolve_index("gndvi")
+
+    image = tiles.index_month_image(
+        {"type": "Polygon", "coordinates": []},
+        2021,
+        4,
+        definition=definition,
+        parameters=params,
+    )
+
+    overrides = {"min": 0.0, "max": 0.8, "palette": "00FF00,FFFFFF"}
+    clamp_range = tiles.resolve_clamp_range(definition, overrides)
+    assert clamp_range == (0.0, 0.8)
+
+    tile = tiles.get_tile_template_for_image(
+        image,
+        definition=definition,
+        vis_overrides=overrides,
+    )
+
+    assert tile["vis"]["min"] == pytest.approx(0.0)
+    assert tile["vis"]["max"] == pytest.approx(0.8)
+    assert tile["vis"]["palette"] == ["00FF00", "FFFFFF"]
+


### PR DESCRIPTION
## Summary
- extend the shared index registry to expose default palettes and visualization helpers
- refactor the tile image builders to work with arbitrary indices and visualization overrides
- add shared Earth Engine fakes and tests covering non-NDVI index tiles and overrides

## Testing
- pytest services/backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cfd49c59e88327b0e97c97d9c15647