### PR TITLE
Parameterize export to support vegetation index selection

### DIFF
--- a/services/backend/app/services/indices.py
+++ b/services/backend/app/services/indices.py
@@ -28,6 +28,7 @@ class IndexDefinition:
     compute: IndexComputer
     default_palette: Tuple[str, ...] | None = None
     parameter_builder: ParameterBuilder = field(default=_default_parameter_builder)
+    default_scale: int = 10
 
     def prepare_parameters(self, params: Mapping[str, Any] | None = None) -> Dict[str, Any]:
         return self.parameter_builder(params)

--- a/services/backend/tests/test_export_indices.py
+++ b/services/backend/tests/test_export_indices.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+from starlette.datastructures import UploadFile
+
+TEST_DIR = Path(__file__).resolve().parent
+if str(TEST_DIR) not in sys.path:
+    sys.path.append(str(TEST_DIR))
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from fake_ee import setup_fake_ee
+
+from app.api import export
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_export_geotiffs_supports_gndvi(monkeypatch):
+    context = setup_fake_ee(monkeypatch, export, [0.4, -0.2])
+
+    monkeypatch.setattr(export, "init_ee", lambda: None)
+    monkeypatch.setattr(
+        export,
+        "shapefile_zip_to_geojson",
+        lambda _content: {"type": "Point", "coordinates": [0, 0]},
+    )
+
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(export, "run_in_threadpool", fake_run_in_threadpool)
+
+    captured_download: dict[str, str] = {}
+
+    def fake_download_bytes(url: str):
+        captured_download["url"] = url
+        return b"II*\x00FAKE", "image/tiff"
+
+    monkeypatch.setattr(export, "_download_bytes", fake_download_bytes)
+
+    upload = UploadFile(filename="field.zip", file=io.BytesIO(b"dummy"))
+
+    response = await export.export_geotiffs(
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+        file=upload,
+        index="gndvi",
+    )
+
+    body = b"".join([chunk async for chunk in response.body_iterator])
+
+    assert (
+        response.headers["Content-Disposition"]
+        == 'attachment; filename="gndvi_2024-01-01_2024-01-31.zip"'
+    )
+    assert response.headers["X-Vegetation-Index"] == "gndvi"
+
+    with zipfile.ZipFile(io.BytesIO(body)) as archive:
+        assert archive.namelist() == ["gndvi_2024_01.tif"]
+        assert archive.read("gndvi_2024_01.tif") == b"II*\x00FAKE"
+
+    assert captured_download["url"] == "https://example.com/download"
+
+    clamp_calls = context["log"].get("clamp_calls", [])
+    assert clamp_calls == [(-1.0, 1.0)]
+
+    download_args = context["log"].get("download_args", [])
+    assert len(download_args) == 1
+    expected_scale = export.resolve_index("gndvi")[0].default_scale
+    assert download_args[0]["scale"] == expected_scale

--- a/services/backend/tests/test_ndvi_negative.py
+++ b/services/backend/tests/test_ndvi_negative.py
@@ -21,7 +21,14 @@ from app.services import tiles
 def test_export_ndvi_range_preserves_negatives(monkeypatch):
     context = setup_fake_ee(monkeypatch, export, [-0.6, -0.2])
 
-    _, image = export._ndvi_image_for_range({"type": "Point", "coordinates": [0, 0]}, "2024-01-01", "2024-02-01")
+    definition, params = export.resolve_index("ndvi")
+    _, image = export._index_image_for_range(
+        {"type": "Point", "coordinates": [0, 0]},
+        "2024-01-01",
+        "2024-02-01",
+        definition=definition,
+        parameters=params,
+    )
 
     assert isinstance(image, FakeMeanImage)
     assert image.clamped_to == (-1, 1)


### PR DESCRIPTION
### **User description**
## Summary
- allow the export endpoint to choose vegetation indices via the registry, applying index-specific scaling, clamping, and filenames
- extend the index definitions and test doubles to expose default scales and download logging
- add regression tests covering NDVI and GNDVI export flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfdd627ed0832785145c59406ef79f


___

### **PR Type**
Enhancement


___

### **Description**
- Parameterize export endpoint to support multiple vegetation indices

- Add index selection via form parameter with registry-based resolution

- Extend index definitions with default scale and download logging

- Add comprehensive regression tests for NDVI and GNDVI workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Export Request"] --> B["Index Resolution"]
  B --> C["Collection Filtering"]
  C --> D["Image Processing"]
  D --> E["Download & Archive"]
  B --> F["Index Registry"]
  F --> G["Scale & Clamping Config"]
  G --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.py</strong><dd><code>Parameterize export for multiple vegetation indices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/export.py

<ul><li>Add <code>index</code> form parameter to export endpoint<br> <li> Replace hardcoded NDVI logic with parameterized index processing<br> <li> Update function names from <code>_ndvi_image_for_range</code> to <br><code>_index_image_for_range</code><br> <li> Add index-specific scaling, clamping, and filename generation</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/40/files#diff-5e2d28a7e848b401191a00d5496480010316038f29a07a93e44dca190ef2a30b">+76/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>indices.py</strong><dd><code>Add default scale to index definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/indices.py

<ul><li>Add <code>default_scale</code> field to <code>IndexDefinition</code> class with default value of <br>10</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/40/files#diff-5a16d3a318a45d807cefb4f446e65a23f30fe058e17a75ce27eeac65035ad0ae">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fake_ee.py</strong><dd><code>Enhance test doubles with download and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/fake_ee.py

<ul><li>Add context parameter to <code>FakeMeanImage</code> constructor<br> <li> Implement <code>getDownloadURL</code> method for download testing<br> <li> Add <code>size</code> method to <code>FakeImageCollection</code><br> <li> Track clamp calls and download arguments in context logging</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/40/files#diff-eb1b84d2342d31c18533ac717a0072d28edfe1f9a93746877a15262b41e7d1ea">+18/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_export_indices.py</strong><dd><code>Add GNDVI export regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_export_indices.py

<ul><li>Add comprehensive test for GNDVI export functionality<br> <li> Verify proper filename generation and headers<br> <li> Test index-specific scaling and clamping behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/40/files#diff-4383466bb5c103d6b440bc045aaec5ec3d35dbe12506993b4d1ec33033360f0c">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_ndvi_negative.py</strong><dd><code>Update NDVI test for parameterized interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_ndvi_negative.py

<ul><li>Update test to use new parameterized <code>_index_image_for_range</code> function<br> <li> Add index resolution step with <code>resolve_index</code> call</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/40/files#diff-c83edcbce25051119f70bba8ef38dc1f1d531e0e140863a6857a4fcafe3f94c0">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

