### PR TITLE
Ensure multi-select uses explicit colours

### DIFF
--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -115,6 +115,11 @@ def export_ui():
         font: inherit;
         background: #ffffff;
       }
+      select,
+      select option {
+        color: #1f2933;
+        background-color: #ffffff;
+      }
       input[type="file"] {
         padding: 0.5rem;
       }


### PR DESCRIPTION
## Summary
- set explicit text and background colours on the `/ui` multi-select so the options remain legible in all themes

## Testing
- browser_container.run_playwright_script (Chromium)
- browser_container.run_playwright_script (Firefox)
- browser_container.run_playwright_script (WebKit)


------
https://chatgpt.com/codex/tasks/task_e_68d125cb37ac8327aa07c294c0bd88fe