### PR TITLE
Fix Sentinel-2 multi-index export endpoints

### DIFF
--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -406,7 +406,7 @@ def export_ui():
       };
 
       const pollJob = async (jobId, exportTarget, headers) => {
-        const statusUrl = buildUrl(`export/s2/${jobId}/status`);
+        const statusUrl = buildUrl(`export/s2/indices/${jobId}/status`);
         while (true) {
           const response = await fetch(statusUrl, { headers });
           if (!response.ok) {
@@ -427,7 +427,7 @@ def export_ui():
       };
 
       const downloadZip = async (jobId, headers) => {
-        const response = await fetch(buildUrl(`export/s2/${jobId}/download`), {
+        const response = await fetch(buildUrl(`export/s2/indices/${jobId}/download`), {
           method: 'GET',
           headers,
         });
@@ -450,7 +450,7 @@ def export_ui():
       };
 
       const fetchExportSummary = async (jobId, headers) => {
-        const response = await fetch(buildUrl(`export/s2/${jobId}/download`), {
+        const response = await fetch(buildUrl(`export/s2/indices/${jobId}/download`), {
           method: 'GET',
           headers,
         });


### PR DESCRIPTION
## Summary
- update the Sentinel-2 export UI helpers so status, ZIP, and summary requests hit the indices-specific endpoints

## Testing
- Playwright: simulated a multi-index export from /ui with stubbed backend responses to confirm the console logs no 404s


------
https://chatgpt.com/codex/tasks/task_e_68d129c76d6c83279b625c2b77d4fd0c