### PR TITLE
Handle mixed-case Sentinel-2 indices

### DIFF
--- a/services/backend/app/api/export.py
+++ b/services/backend/app/api/export.py
@@ -257,13 +257,18 @@ def _normalise_indices(values: List[str]) -> List[str]:
     if not values:
         raise HTTPException(status_code=400, detail="At least one index must be specified.")
 
+    canonical_lookup = {
+        name.lower(): name for name in sentinel_indices.SUPPORTED_INDICES
+    }
+
     cleaned: List[str] = []
     for value in values:
-        upper = value.upper()
-        if upper not in sentinel_indices.SUPPORTED_INDICES:
+        key = str(value).strip()
+        canonical = canonical_lookup.get(key.lower())
+        if canonical is None:
             raise HTTPException(status_code=400, detail=f"Unsupported index: {value}")
-        if upper not in cleaned:
-            cleaned.append(upper)
+        if canonical not in cleaned:
+            cleaned.append(canonical)
     return cleaned
 
 

--- a/services/backend/app/api/s2_indices.py
+++ b/services/backend/app/api/s2_indices.py
@@ -121,13 +121,15 @@ class Sentinel2ExportRequest(BaseModel):
     def _validate_indices(cls, value: List[str]) -> List[str]:
         if not value:
             raise ValueError("At least one index must be specified")
-        normalised = []
+        canonical_lookup = {name.lower(): name for name in indices.SUPPORTED_INDICES}
+        normalised: List[str] = []
         for index in value:
-            upper = index.upper()
-            if upper not in indices.SUPPORTED_INDICES:
+            key = str(index).strip()
+            canonical = canonical_lookup.get(key.lower())
+            if canonical is None:
                 raise ValueError(f"Unsupported index: {index}")
-            if upper not in normalised:
-                normalised.append(upper)
+            if canonical not in normalised:
+                normalised.append(canonical)
         return normalised
 
     @validator("scale_m")


### PR DESCRIPTION
## Summary
- normalise Sentinel-2 index inputs case-insensitively so canonical codes are queued
- update Sentinel2ExportRequest validators to deduplicate based on canonical names
- extend tests to cover mixed-case index inputs and ensure queued jobs use canonical identifiers

## Testing
- pytest services/backend/tests/test_export_indices.py

------
https://chatgpt.com/codex/tasks/task_e_68d1391c9d1483278a177d26154ef38b