### PR TITLE
Adjust UI base path handling for export flow

### DIFF
--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -265,9 +265,11 @@ def export_ui():
       const clearAllIndicesButton = document.getElementById('clear-all-indices');
 
       const { origin, pathname } = window.location;
-      const basePath = pathname.replace(/\/[^/]*$/, '/') || '/';
+      const lastSlashIndex = pathname.lastIndexOf('/');
+      const basePath =
+        lastSlashIndex >= 0 ? pathname.slice(0, lastSlashIndex + 1) || '/' : '/';
       const buildUrl = (path) => {
-        const cleaned = path.replace(/^\//, '');
+        const cleaned = path.replace(/^\/+/, '');
         return new URL(`${basePath}${cleaned}`, origin);
       };
 


### PR DESCRIPTION
## Summary
- derive the Sentinel-2 export UI base path from the last slash in the current pathname so trailing segments such as `/ui` are dropped while retaining a terminal slash
- normalise requested API paths by stripping any leading slashes before composing URLs against the resolved base path

## Testing
- pytest
- playwright script verifying /ui export workflow against the fake export server


------
https://chatgpt.com/codex/tasks/task_e_68d13babd8cc8327ad1b0c7cd9841e6d