### PR TITLE
Refresh Sentinel-2 export UI layout

### DIFF
--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -65,553 +65,823 @@ def export_ui():
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Sentinel-2 Index Export</title>
     <style>
-      :root {
-        color-scheme: light dark;
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      }
-      body {
+      * {
         margin: 0;
-        background: #f7f7f7;
+        padding: 0;
+        box-sizing: border-box;
       }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background-color: #f5f5f5;
+        padding: 20px;
+      }
+
       .container {
-        max-width: 720px;
-        margin: 4rem auto;
-        padding: 2.75rem;
+        max-width: 840px;
+        margin: 0 auto;
         background: #ffffff;
-        border-radius: 12px;
-        box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+        border-radius: 16px;
+        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
+        padding: 40px;
       }
-      h1 {
-        margin-top: 0;
-        margin-bottom: 1rem;
-        font-size: 1.875rem;
-        line-height: 1.2;
+
+      .header {
+        text-align: center;
+        margin-bottom: 32px;
+      }
+
+      .title {
+        font-size: 32px;
+        font-weight: 600;
         color: #1f2933;
-        text-align: center;
+        margin-bottom: 16px;
       }
-      p.instructions {
+
+      .description {
         color: #475569;
-        font-size: 0.95rem;
-        margin-bottom: 2rem;
-        text-align: center;
+        line-height: 1.6;
+        font-size: 15px;
+        max-width: 580px;
+        margin: 0 auto;
       }
+
       form {
         display: grid;
-        gap: 1.35rem;
+        gap: 24px;
       }
-      label {
-        display: grid;
-        gap: 0.5rem;
+
+      .form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .label {
         font-weight: 600;
         color: #1f2933;
+        font-size: 14px;
       }
-      input[type="date"],
-      input[type="text"],
-      input[type="file"],
-      select {
-        padding: 0.65rem 0.75rem;
-        border: 1px solid #cbd5e1;
-        border-radius: 8px;
-        font: inherit;
-        background: #ffffff;
+
+      .file-upload {
+        border: 2px dashed #d0d7e3;
+        border-radius: 12px;
+        padding: 24px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        background: #f8fafc;
+        cursor: pointer;
+        transition: all 0.2s ease;
       }
-      select,
-      select option {
-        color: #1f2933;
-        background-color: #ffffff;
+
+      .file-upload:focus,
+      .file-upload:hover {
+        border-color: #4285f4;
+        background: #f4f8ff;
       }
-      input[type="file"] {
-        padding: 0.5rem;
-      }
-      select[multiple] {
-        min-height: 10rem;
-      }
-      .hint {
-        font-weight: 400;
-        font-size: 0.85rem;
-        color: #64748b;
-      }
-      button {
-        padding: 0.85rem 1.6rem;
-        border: none;
-        border-radius: 999px;
-        background: #2563eb;
+
+      .file-upload-button {
+        background: #4a5568;
         color: #ffffff;
-        font-weight: 600;
+        border: none;
+        padding: 10px 18px;
+        border-radius: 8px;
+        font-size: 13px;
         cursor: pointer;
         transition: background 0.2s ease;
-        font: inherit;
       }
-      button:hover {
-        background: #1d4ed8;
+
+      .file-upload-button:hover {
+        background: #2d3748;
       }
-      button:disabled {
+
+      .file-status {
+        color: #475569;
+        font-size: 14px;
+        flex: 1;
+      }
+
+      .file-help {
+        color: #6b7280;
+        font-size: 13px;
+      }
+
+      .input-field,
+      .select-field {
+        width: 100%;
+        padding: 12px;
+        border: 1px solid #d0d7e3;
+        border-radius: 10px;
+        font-size: 14px;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .input-field:focus,
+      .select-field:focus {
+        outline: none;
+        border-color: #4285f4;
+        box-shadow: 0 0 0 3px rgba(66, 133, 244, 0.15);
+      }
+
+      .help-text {
+        color: #64748b;
+        font-size: 13px;
+        line-height: 1.5;
+      }
+
+      .checkbox-controls {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .control-button {
+        background: #ffffff;
+        border: 1px solid #4285f4;
+        color: #4285f4;
+        padding: 8px 18px;
+        border-radius: 999px;
+        font-size: 12px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .control-button:hover {
+        background: #4285f4;
+        color: #ffffff;
+      }
+
+      .checkbox-group {
+        border: 1px solid #d0d7e3;
+        border-radius: 10px;
+        max-height: 220px;
+        overflow-y: auto;
+        background: #ffffff;
+      }
+
+      .checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        border-bottom: 1px solid #f1f5f9;
+      }
+
+      .checkbox-item:last-child {
+        border-bottom: none;
+      }
+
+      .checkbox-item input {
+        width: 18px;
+        height: 18px;
+      }
+
+      .checkbox-item label {
+        color: #1f2933;
+        font-size: 14px;
+        cursor: pointer;
+      }
+
+      .checkbox-help {
+        color: #6b7280;
+        font-size: 12px;
+      }
+
+      .export-button {
+        width: 100%;
+        background: #4285f4;
+        color: #ffffff;
+        border: none;
+        padding: 16px;
+        border-radius: 12px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      .export-button:hover {
+        background: #3367d6;
+        transform: translateY(-1px);
+      }
+
+      .export-button:disabled {
         background: #94a3b8;
         cursor: not-allowed;
+        transform: none;
       }
-      .button-secondary {
-        padding: 0.5rem 1.25rem;
-        background: transparent;
-        border: 1px solid #2563eb;
-        color: #2563eb;
-      }
-      .button-secondary:hover {
-        background: rgba(37, 99, 235, 0.1);
-      }
-      .multi-select-actions {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        margin-top: -0.25rem;
-      }
-      #status {
-        min-height: 1.75rem;
-        font-size: 0.95rem;
+
+      .status-message {
         text-align: center;
+        font-size: 14px;
+        margin-top: 12px;
+        font-weight: 500;
+        display: none;
       }
-      #status.success {
-        color: #047857;
+
+      .status-message.pending {
+        color: #4285f4;
       }
-      #status.error {
-        color: #b91c1c;
+
+      .status-message.success {
+        color: #0f9d58;
       }
-      #status.pending {
-        color: #334155;
+
+      .status-message.error {
+        color: #d93025;
+      }
+
+      @media (max-width: 640px) {
+        body {
+          padding: 16px;
+        }
+
+        .container {
+          padding: 28px 20px;
+        }
+
+        .title {
+          font-size: 26px;
+        }
+        .checkbox-controls {
+          gap: 8px;
+        }
       }
     </style>
-  </head>
-  <body>
-    <main class="container">
-      <h1>Sentinel-2 Index Export</h1>
-      <p class="instructions">
-        Upload a zipped shapefile bundle containing .shp, .dbf, and .shx files, choose your
-        date range, pick the vegetation indices to include, and select the export destination.
-        The workflow will queue one export per month for every index, so a broader date range
-        or more indices means more GeoTIFFs will be built for you.
-      </p>
-      <form id="export-form" novalidate>
-        <label for="file">
-          Shapefile archive (.zip)
-          <input id="file" name="file" type="file" accept=".zip" required />
-          <span class="hint">Include the .shp, .dbf, and .shx members in a single ZIP file.</span>
-        </label>
-        <label for="start_date">
-          Start date
-          <input id="start_date" name="start_date" type="date" required />
-        </label>
-        <label for="end_date">
-          End date
-          <input id="end_date" name="end_date" type="date" required />
-          <span class="hint">Every month that overlaps the range will be exported.</span>
-        </label>
-        <label for="aoi_name">
-          AOI name
-          <input id="aoi_name" name="aoi_name" type="text" placeholder="Used in file names" required />
-        </label>
-        <label for="indices">
-          Vegetation indices to export
-          <div class="multi-select-actions">
-            <button type="button" id="select-all-indices" class="button-secondary">Select all</button>
-            <button type="button" id="clear-all-indices" class="button-secondary">Clear all</button>
-          </div>
-          <select id="indices" name="indices" multiple size="10" required>
-            <option value="NDVI" selected>NDVI</option>
-            <option value="EVI">EVI</option>
-            <option value="GNDVI">GNDVI</option>
-            <option value="NDRE">NDRE</option>
-            <option value="SAVI">SAVI</option>
-            <option value="MSAVI">MSAVI</option>
-            <option value="VARI">VARI</option>
-            <option value="MCARI">MCARI</option>
-            <option value="NDWI_McFeeters">NDWI (McFeeters)</option>
-            <option value="NDWI_Gao">NDWI (Gao)</option>
-            <option value="NDMI">NDMI</option>
-            <option value="MSI">MSI</option>
-            <option value="GVMI">GVMI</option>
-            <option value="NBR">NBR</option>
-            <option value="PSRI">PSRI</option>
-            <option value="ARI">ARI</option>
-            <option value="CRI">CRI</option>
-            <option value="BSI">BSI</option>
-            <option value="SBI">SBI</option>
-            <option value="NDSI_Soil">NDSI (Soil)</option>
-            <option value="NDTI">NDTI</option>
-            <option value="PRI">PRI</option>
-          </select>
-          <span class="hint">Use the Select all / Clear all shortcuts or hold Ctrl (Windows/Linux) or ⌘ (macOS) to choose multiple indices.</span>
-        </label>
-        <label for="export_target">
-          Export destination
-          <select id="export_target" name="export_target">
-            <option value="zip" selected>Download ZIP</option>
-            <option value="gcs">Google Cloud Storage</option>
-            <option value="drive">Google Drive</option>
-          </select>
-        </label>
-        <label for="api_key">
-          API key (optional)
-          <input id="api_key" name="api_key" type="text" placeholder="x-api-key value" />
-        </label>
-        <button type="submit">Start export</button>
-      </form>
-      <div id="status" role="status" aria-live="polite"></div>
-    </main>
-    <script>
-      const form = document.getElementById('export-form');
-      const statusEl = document.getElementById('status');
-      const submitButton = form.querySelector('button[type="submit"]');
-      const indicesSelect = document.getElementById('indices');
-      const selectAllIndicesButton = document.getElementById('select-all-indices');
-      const clearAllIndicesButton = document.getElementById('clear-all-indices');
+   </head>
+   <body>
+     <div class="container">
+       <div class="header">
+         <h1 class="title">Sentinel-2 Index Export</h1>
+         <p class="description">
+           Upload a zipped shapefile bundle (containing .shp, .dbf, and .shx files), choose the
+           date range to cover, pick the vegetation indices you need, and decide where the exports
+           should be delivered. One export is created per month for every index you select.
+         </p>
+       </div>
 
-      const { origin, pathname } = window.location;
-      const lastSlashIndex = pathname.lastIndexOf('/');
-      const basePath =
-        lastSlashIndex >= 0 ? pathname.slice(0, lastSlashIndex + 1) || '/' : '/';
-      const buildUrl = (path) => {
-        const cleaned = path.replace(/^\/+/, '');
-        return new URL(`${basePath}${cleaned}`, origin);
-      };
+       <form id="exportForm" novalidate>
+         <div class="form-group">
+           <label class="label" for="fileInput">Shapefile archive (.zip)</label>
+           <div class="file-upload" id="fileUpload" role="button" tabindex="0">
+             <input type="file" id="fileInput" name="file" accept=".zip" style="display: none" required />
+             <button type="button" class="file-upload-button">Choose file</button>
+             <span class="file-status">No file chosen</span>
+           </div>
+           <div class="file-help">Include the .shp, .dbf, and .shx members in a single ZIP file.</div>
+         </div>
 
-      const POLL_INTERVAL_MS = 5000;
+         <div class="form-group">
+           <label class="label" for="startDate">Start date</label>
+           <input type="date" class="input-field" id="startDate" name="start_date" required />
+         </div>
 
-      const setStatus = (message, type = 'pending') => {
-        statusEl.textContent = message;
-        statusEl.className = type;
-      };
+         <div class="form-group">
+           <label class="label" for="endDate">End date</label>
+           <input type="date" class="input-field" id="endDate" name="end_date" required />
+           <div class="help-text">Every month that overlaps the range will be exported.</div>
+         </div>
 
-      const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+         <div class="form-group">
+           <label class="label" for="aoiName">Paddock name</label>
+           <input type="text" class="input-field" id="aoiName" name="aoi_name" placeholder="Used in file names" required />
+         </div>
 
-      const readError = async (response) => {
-        try {
-          const data = await response.json();
-          if (data) {
-            if (Array.isArray(data.detail)) {
-              return data.detail.join(', ');
-            }
-            if (data.detail) {
-              return data.detail;
-            }
-            if (typeof data.message === 'string') {
-              return data.message;
-            }
-            if (typeof data.error === 'string') {
-              return data.error;
-            }
-          }
-        } catch (error) {
-          // ignore JSON parsing failures and fall back to status text
-        }
-        return response.statusText || `HTTP ${response.status}`;
-      };
+         <div class="form-group">
+           <label class="label" for="indicesGroup">Vegetation indices to export</label>
+           <div class="checkbox-controls">
+             <button type="button" class="control-button" id="selectAllIndices">Select all</button>
+             <button type="button" class="control-button" id="clearAllIndices">Clear all</button>
+           </div>
+           <div class="checkbox-group" id="indicesGroup">
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ndvi" name="indices" value="NDVI" checked />
+               <label for="index-ndvi">NDVI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-evi" name="indices" value="EVI" />
+               <label for="index-evi">EVI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-gndvi" name="indices" value="GNDVI" />
+               <label for="index-gndvi">GNDVI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ndre" name="indices" value="NDRE" />
+               <label for="index-ndre">NDRE</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-savi" name="indices" value="SAVI" />
+               <label for="index-savi">SAVI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-msavi" name="indices" value="MSAVI" />
+               <label for="index-msavi">MSAVI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-vari" name="indices" value="VARI" />
+               <label for="index-vari">VARI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-mcari" name="indices" value="MCARI" />
+               <label for="index-mcari">MCARI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ndwi-mcfeeters" name="indices" value="NDWI_McFeeters" />
+               <label for="index-ndwi-mcfeeters">NDWI (McFeeters)</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ndwi-gao" name="indices" value="NDWI_Gao" />
+               <label for="index-ndwi-gao">NDWI (Gao)</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ndmi" name="indices" value="NDMI" />
+               <label for="index-ndmi">NDMI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-msi" name="indices" value="MSI" />
+               <label for="index-msi">MSI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-gvmi" name="indices" value="GVMI" />
+               <label for="index-gvmi">GVMI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-nbr" name="indices" value="NBR" />
+               <label for="index-nbr">NBR</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-psri" name="indices" value="PSRI" />
+               <label for="index-psri">PSRI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ari" name="indices" value="ARI" />
+               <label for="index-ari">ARI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-cri" name="indices" value="CRI" />
+               <label for="index-cri">CRI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-bsi" name="indices" value="BSI" />
+               <label for="index-bsi">BSI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-sbi" name="indices" value="SBI" />
+               <label for="index-sbi">SBI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ndsi-soil" name="indices" value="NDSI_Soil" />
+               <label for="index-ndsi-soil">NDSI (Soil)</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-ndti" name="indices" value="NDTI" />
+               <label for="index-ndti">NDTI</label>
+             </div>
+             <div class="checkbox-item">
+               <input type="checkbox" id="index-pri" name="indices" value="PRI" />
+               <label for="index-pri">PRI</label>
+             </div>
+           </div>
+           <div class="checkbox-help">
+             Use Select all / Clear all or hold Ctrl (Windows/Linux) or ⌘ (macOS) to toggle multiple entries quickly.
+           </div>
+         </div>
 
-      const deriveMonths = (startValue, endValue) => {
-        if (!startValue || !endValue) {
-          throw new Error('Please choose both start and end dates.');
-        }
-        const parseIsoDate = (value) => {
-          const parts = value.split('-').map((part) => Number.parseInt(part, 10));
-          if (parts.length < 3 || parts.some((part) => Number.isNaN(part))) {
-            throw new Error('Dates must be provided in YYYY-MM-DD format.');
-          }
-          const [year, month, day] = parts;
-          return new Date(Date.UTC(year, month - 1, day));
-        };
-        const startDate = parseIsoDate(startValue);
-        const endDate = parseIsoDate(endValue);
-        if (startDate > endDate) {
-          throw new Error('The start date must be on or before the end date.');
-        }
-        const months = [];
-        const current = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), 1));
-        const last = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 1));
-        while (current <= last) {
-          const year = current.getUTCFullYear();
-          const month = String(current.getUTCMonth() + 1).padStart(2, '0');
-          months.push(`${year}-${month}`);
-          current.setUTCMonth(current.getUTCMonth() + 1);
-        }
-        return months;
-      };
+         <div class="form-group">
+           <label class="label" for="exportDestination">Export destination</label>
+           <select class="select-field" id="exportDestination" name="export_target">
+             <option value="zip" selected>Download ZIP</option>
+             <option value="gcs">Google Cloud Storage</option>
+             <option value="drive">Google Drive</option>
+           </select>
+         </div>
 
-      const uploadAndFetchGeometry = async (file, aoiName, headers) => {
-        const uploadUrl = buildUrl('export/s2/indices/aoi');
-        const formData = new FormData();
-        formData.append('file', file);
-        if (aoiName) {
-          formData.append('aoi_name', aoiName);
-        }
-        const uploadResponse = await fetch(uploadUrl, {
-          method: 'POST',
-          headers,
-          body: formData,
-        });
-        if (!uploadResponse.ok) {
-          throw new Error(await readError(uploadResponse));
-        }
-        const payload = await uploadResponse.json();
-        if (!payload || !payload.geometry) {
-          throw new Error('AOI geometry was not returned by the server.');
-        }
-        return payload;
-      };
+         <div class="form-group">
+           <label class="label" for="apiKey">API key (optional)</label>
+           <input type="text" class="input-field" id="apiKey" name="api_key" placeholder="x-api-key value" />
+           <div class="help-text">Only required when API key enforcement is enabled for the backend.</div>
+         </div>
 
-      const updateProgress = (job, exportTarget) => {
-        const items = Array.isArray(job.items) ? job.items : [];
-        const total = items.length;
-        const completed = items.filter((item) => item.status === 'completed').length;
-        const failed = items.filter((item) => item.status === 'failed').length;
-        const active = items.filter((item) => !['completed', 'failed'].includes(item.status)).length;
+         <button type="submit" class="export-button">Start export</button>
+         <div class="status-message" id="statusMessage" role="status" aria-live="polite"></div>
+       </form>
+     </div>
 
-        let message = 'Checking export status…';
-        let type = 'pending';
+     <script>
+       const form = document.getElementById('exportForm');
+       const fileUpload = document.getElementById('fileUpload');
+       const fileInput = document.getElementById('fileInput');
+       const fileStatus = document.querySelector('.file-status');
+       const exportButton = document.querySelector('.export-button');
+       const statusMessage = document.getElementById('statusMessage');
+       const selectAllButton = document.getElementById('selectAllIndices');
+       const clearAllButton = document.getElementById('clearAllIndices');
+       const startDateInput = document.getElementById('startDate');
+       const endDateInput = document.getElementById('endDate');
+       const aoiNameInput = document.getElementById('aoiName');
+       const exportDestinationSelect = document.getElementById('exportDestination');
+       const apiKeyInput = document.getElementById('apiKey');
 
-        switch (job.state) {
-          case 'pending':
-            message = `Export job queued… ${completed} of ${total} ready${failed ? ` (${failed} failed)` : ''}.`;
-            break;
-          case 'running':
-            message = `Building exports: ${completed} of ${total} ready${failed ? ` (${failed} failed)` : ''}${active ? `, ${active} in progress` : ''}.`;
-            break;
-          case 'partial':
-            if (exportTarget === 'zip') {
-              message = `Exports ready with warnings: ${completed} of ${total} available (${failed} failed). Successful files will download as a ZIP.`;
-            } else {
-              message = `Exports ready with warnings: ${completed} of ${total} available (${failed} failed). Destination links will follow.`;
-            }
-            break;
-          case 'completed':
-            message = `Exports ready: ${completed} of ${total} available.`;
-            break;
-          case 'failed':
-            message = job.error ? `Export failed: ${job.error}` : 'Export failed.';
-            type = 'error';
-            break;
-          default:
-            message = `Job status: ${job.state || 'unknown'}.`;
-        }
+       const { origin, pathname } = window.location;
+       const lastSlashIndex = pathname.lastIndexOf('/');
+       const basePath = lastSlashIndex >= 0 ? pathname.slice(0, lastSlashIndex + 1) || '/' : '/';
 
-        setStatus(message, type);
-      };
+       const buildUrl = (path) => {
+         const cleaned = path.replace(/^\/+/, '');
+         return new URL(`${basePath}${cleaned}`, origin);
+       };
 
-      const pollJob = async (jobId, exportTarget, headers) => {
-        const statusUrl = buildUrl(`export/s2/indices/${jobId}/status`);
-        while (true) {
-          const response = await fetch(statusUrl, { headers });
-          if (!response.ok) {
-            throw new Error(await readError(response));
-          }
-          const job = await response.json();
-          updateProgress(job, exportTarget);
+       const POLL_INTERVAL_MS = 5000;
 
-          if (job.state === 'failed') {
-            throw new Error(job.error || 'Export job failed.');
-          }
-          if (job.state === 'completed' || job.state === 'partial') {
-            return job;
-          }
+       const getIndicesCheckboxes = () => Array.from(document.querySelectorAll('input[name="indices"]'));
 
-          await sleep(POLL_INTERVAL_MS);
-        }
-      };
+       const updateFileStatus = (text) => {
+         fileStatus.textContent = text || 'No file chosen';
+       };
 
-      const downloadZip = async (jobId, headers) => {
-        const response = await fetch(buildUrl(`export/s2/indices/${jobId}/download`), {
-          method: 'GET',
-          headers,
-        });
-        if (!response.ok) {
-          throw new Error(await readError(response));
-        }
-        const blob = await response.blob();
-        const disposition = response.headers.get('content-disposition') || '';
-        const match = disposition.match(/filename\*?=(?:UTF-8''|"?)([^";]+)/i);
-        const filename = match ? decodeURIComponent(match[1]) : 'sentinel2_indices.zip';
+       const setStatus = (message, type = 'pending') => {
+         if (!message) {
+           statusMessage.textContent = '';
+           statusMessage.className = 'status-message';
+           statusMessage.style.display = 'none';
+           return;
+         }
+         statusMessage.textContent = message;
+         statusMessage.className = `status-message ${type}`;
+         statusMessage.style.display = 'block';
+       };
 
-        const url = window.URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = filename;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        window.URL.revokeObjectURL(url);
-      };
+       const setProcessingState = (processing) => {
+         exportButton.disabled = processing;
+         exportButton.textContent = processing ? 'Processing…' : 'Start export';
+       };
 
-      const fetchExportSummary = async (jobId, headers) => {
-        const response = await fetch(buildUrl(`export/s2/indices/${jobId}/download`), {
-          method: 'GET',
-          headers,
-        });
-        if (!response.ok) {
-          throw new Error(await readError(response));
-        }
-        return response.json();
-      };
+       const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-      let isProcessing = false;
+       const readError = async (response) => {
+         try {
+           const data = await response.json();
+           if (data) {
+             if (Array.isArray(data.detail)) {
+               return data.detail.join(', ');
+             }
+             if (data.detail) {
+               return data.detail;
+             }
+             if (typeof data.message === 'string') {
+               return data.message;
+             }
+             if (typeof data.error === 'string') {
+               return data.error;
+             }
+           }
+         } catch (error) {
+           // Ignore JSON parsing failures and fall back to status text.
+         }
+         return response.statusText || `HTTP ${response.status}`;
+       };
 
-      const setIndicesSelection = (selected) => {
-        if (!indicesSelect) {
-          return;
-        }
-        Array.from(indicesSelect.options).forEach((option) => {
-          option.selected = selected;
-        });
-        const changeEvent = new Event('change', { bubbles: true });
-        indicesSelect.dispatchEvent(changeEvent);
-        indicesSelect.focus();
-      };
+       const deriveMonths = (startValue, endValue) => {
+         if (!startValue || !endValue) {
+           throw new Error('Please choose both start and end dates.');
+         }
+         const parseIsoDate = (value) => {
+           const parts = value.split('-').map((part) => Number.parseInt(part, 10));
+           if (parts.length < 3 || parts.some((part) => Number.isNaN(part))) {
+             throw new Error('Dates must be provided in YYYY-MM-DD format.');
+           }
+           const [year, month, day] = parts;
+           return new Date(Date.UTC(year, month - 1, day));
+         };
+         const startDate = parseIsoDate(startValue);
+         const endDate = parseIsoDate(endValue);
+         if (startDate > endDate) {
+           throw new Error('The start date must be on or before the end date.');
+         }
+         const months = [];
+         const current = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), 1));
+         const last = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 1));
+         while (current <= last) {
+           const year = current.getUTCFullYear();
+           const month = String(current.getUTCMonth() + 1).padStart(2, '0');
+           months.push(`${year}-${month}`);
+           current.setUTCMonth(current.getUTCMonth() + 1);
+         }
+         return months;
+       };
 
-      if (selectAllIndicesButton) {
-        selectAllIndicesButton.addEventListener('click', () => setIndicesSelection(true));
-      }
+       const uploadAndFetchGeometry = async (file, aoiName, headers) => {
+         const uploadUrl = buildUrl('export/s2/indices/aoi');
+         const formData = new FormData();
+         formData.append('file', file);
+         if (aoiName) {
+           formData.append('aoi_name', aoiName);
+         }
+         const uploadResponse = await fetch(uploadUrl, {
+           method: 'POST',
+           headers,
+           body: formData,
+         });
+         if (!uploadResponse.ok) {
+           throw new Error(await readError(uploadResponse));
+         }
+         const payload = await uploadResponse.json();
+         if (!payload || !payload.geometry) {
+           throw new Error('AOI geometry was not returned by the server.');
+         }
+         return payload;
+       };
 
-      if (clearAllIndicesButton) {
-        clearAllIndicesButton.addEventListener('click', () => setIndicesSelection(false));
-      }
+       const updateProgress = (job, exportTarget) => {
+         const items = Array.isArray(job.items) ? job.items : [];
+         const total = items.length;
+         const completed = items.filter((item) => item.status === 'completed').length;
+         const failed = items.filter((item) => item.status === 'failed').length;
+         const active = items.filter((item) => !['completed', 'failed'].includes(item.status)).length;
 
-      form.addEventListener('submit', async (event) => {
-        event.preventDefault();
-        if (isProcessing) {
-          return;
-        }
+         let message = 'Checking export status…';
+         let type = 'pending';
 
-        const fileInput = document.getElementById('file');
-        const startInput = document.getElementById('start_date');
-        const endInput = document.getElementById('end_date');
-        const aoiNameInput = document.getElementById('aoi_name');
-        const exportTargetSelect = document.getElementById('export_target');
-        const apiKeyInput = document.getElementById('api_key');
+         switch (job.state) {
+           case 'pending':
+             message = `Export job queued… ${completed} of ${total} ready${failed ? ` (${failed} failed)` : ''}.`;
+             break;
+           case 'running':
+             message = `Building exports: ${completed} of ${total} ready${failed ? ` (${failed} failed)` : ''}${active ? `, ${active} in progress` : ''}.`;
+             break;
+           case 'partial':
+             if (exportTarget === 'zip') {
+               message = `Exports ready with warnings: ${completed} of ${total} available (${failed} failed). Successful files will download as a ZIP.`;
+             } else {
+               message = `Exports ready with warnings: ${completed} of ${total} available (${failed} failed). Destination links will follow.`;
+             }
+             break;
+           case 'completed':
+             message = `Exports ready: ${completed} of ${total} available.`;
+             break;
+           case 'failed':
+             message = job.error ? `Export failed: ${job.error}` : 'Export failed.';
+             type = 'error';
+             break;
+           default:
+             message = `Job status: ${job.state || 'unknown'}.`;
+         }
 
-        if (!fileInput.files.length) {
-          setStatus('Please select a zipped shapefile bundle before submitting.', 'error');
-          fileInput.focus();
-          return;
-        }
+         setStatus(message, type);
+       };
 
-        if (!form.reportValidity()) {
-          setStatus('Please complete the highlighted fields before submitting.', 'error');
-          return;
-        }
+       const pollJob = async (jobId, exportTarget, headers) => {
+         const statusUrl = buildUrl(`export/s2/indices/${jobId}/status`);
+         while (true) {
+           const response = await fetch(statusUrl, { headers });
+           if (!response.ok) {
+             throw new Error(await readError(response));
+           }
+           const job = await response.json();
+           updateProgress(job, exportTarget);
 
-        const selectedIndices = Array.from(indicesSelect.selectedOptions).map((option) => option.value);
-        if (!selectedIndices.length) {
-          setStatus('Select at least one vegetation index to export.', 'error');
-          indicesSelect.focus();
-          return;
-        }
+           if (job.state === 'failed') {
+             throw new Error(job.error || 'Export job failed.');
+           }
+           if (job.state === 'completed' || job.state === 'partial') {
+             return job;
+           }
 
-        let months;
-        try {
-          months = deriveMonths(startInput.value, endInput.value);
-        } catch (error) {
-          setStatus(error instanceof Error ? error.message : String(error), 'error');
-          return;
-        }
+           await sleep(POLL_INTERVAL_MS);
+         }
+       };
 
-        const apiKey = apiKeyInput.value.trim();
-        const headers = apiKey ? { 'x-api-key': apiKey } : {};
-        const exportTarget = exportTargetSelect.value;
-        const aoiName = aoiNameInput.value.trim();
-        const monthCount = months.length;
-        const indexCount = selectedIndices.length;
+       const downloadZip = async (jobId, headers) => {
+         const response = await fetch(buildUrl(`export/s2/indices/${jobId}/download`), {
+           method: 'GET',
+           headers,
+         });
+         if (!response.ok) {
+           throw new Error(await readError(response));
+         }
+         const blob = await response.blob();
+         const disposition = response.headers.get('content-disposition') || '';
+         const match = disposition.match(/filename\*?=(?:UTF-8''|"?)([^";]+)/i);
+         const filename = match ? decodeURIComponent(match[1]) : 'sentinel2_indices.zip';
 
-        setStatus('Uploading shapefile to prepare AOI geometry…', 'pending');
-        isProcessing = true;
-        submitButton.disabled = true;
+         const url = window.URL.createObjectURL(blob);
+         const link = document.createElement('a');
+         link.href = url;
+         link.download = filename;
+         document.body.appendChild(link);
+         link.click();
+         link.remove();
+         window.URL.revokeObjectURL(url);
+       };
 
-        try {
-          const aoiPayload = await uploadAndFetchGeometry(fileInput.files[0], aoiName, headers);
-          const { geometry, aoi_name: sanitizedAoiName } = aoiPayload;
-          const jobAoiName = sanitizedAoiName || aoiName;
-          if (sanitizedAoiName && sanitizedAoiName !== aoiName) {
-            console.info(`AOI name sanitised to "${sanitizedAoiName}" for export filenames.`);
-          }
+       const fetchExportSummary = async (jobId, headers) => {
+         const response = await fetch(buildUrl(`export/s2/indices/${jobId}/download`), {
+           method: 'GET',
+           headers,
+         });
+         if (!response.ok) {
+           throw new Error(await readError(response));
+         }
+         return response.json();
+       };
 
-          setStatus('Queueing Sentinel-2 export job…', 'pending');
+       let isProcessing = false;
 
-          const queueResponse = await fetch(buildUrl('export/s2/indices'), {
-            method: 'POST',
-            headers: { ...headers, 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              aoi_geojson: geometry,
-              months,
-              indices: selectedIndices,
-              export_target: exportTarget,
-              aoi_name: jobAoiName,
-            }),
-          });
+       const setIndicesSelection = (checked) => {
+         getIndicesCheckboxes().forEach((checkbox) => {
+           checkbox.checked = checked;
+         });
+         const firstCheckbox = getIndicesCheckboxes()[0];
+         if (firstCheckbox) {
+           firstCheckbox.focus();
+         }
+       };
 
-          if (!queueResponse.ok) {
-            throw new Error(await readError(queueResponse));
-          }
+       if (selectAllButton) {
+         selectAllButton.addEventListener('click', () => setIndicesSelection(true));
+       }
 
-          const data = await queueResponse.json();
-          const jobId = data.job_id;
-          if (!jobId) {
-            throw new Error('Export job did not return an identifier.');
-          }
+       if (clearAllButton) {
+         clearAllButton.addEventListener('click', () => setIndicesSelection(false));
+       }
 
-          setStatus('Export job queued. Building composites…', 'pending');
+       const setDefaultDates = () => {
+         const today = new Date();
+         const threeMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 3, today.getDate());
+         endDateInput.value = today.toISOString().split('T')[0];
+         startDateInput.value = threeMonthsAgo.toISOString().split('T')[0];
+       };
 
-          const finalStatus = await pollJob(jobId, exportTarget, headers);
+       setDefaultDates();
 
-          if (exportTarget === 'zip') {
-            setStatus('Exports ready. Preparing ZIP download…', 'pending');
-            await downloadZip(jobId, headers);
-          } else {
-            const summary = await fetchExportSummary(jobId, headers);
-            if (summary && Array.isArray(summary.items)) {
-              console.groupCollapsed('Sentinel-2 export destinations');
-              summary.items.forEach((item) => {
-                const destination = item.signed_url || item.destination_uri || 'pending';
-                console.log(`${item.month} ${item.index}: ${destination}`);
-              });
-              console.groupEnd();
-            } else {
-              console.info('Export summary', summary);
-            }
-          }
+       fileUpload.addEventListener('click', () => {
+         fileInput.click();
+       });
 
-          const items = Array.isArray(finalStatus.items) ? finalStatus.items : [];
-          const successful = items.filter((item) => item.status === 'completed').length;
-          const failed = items.filter((item) => item.status === 'failed').length;
-          const total = items.length;
-          const monthLabel = monthCount === 1 ? 'month' : 'months';
-          const indexLabel = indexCount === 1 ? 'index' : 'indices';
-          const destinationNote = exportTarget === 'zip' ? '' : ' Destinations have been logged to the browser console.';
+       fileUpload.addEventListener('keydown', (event) => {
+         if (event.key === 'Enter' || event.key === ' ') {
+           event.preventDefault();
+           fileInput.click();
+         }
+       });
 
-          if (failed > 0) {
-            const warningPrefix = exportTarget === 'zip' ? 'Download finished with warnings' : 'Exports finished with warnings';
-            setStatus(
-              `${warningPrefix}: ${successful} of ${total} exports succeeded (${failed} failed) across ${monthCount} ${monthLabel} × ${indexCount} ${indexLabel}.${destinationNote}`,
-              'success'
-            );
-          } else {
-            const completionPrefix = exportTarget === 'zip' ? 'Download complete' : 'Exports complete';
-            const summary = exportTarget === 'zip'
-              ? `${successful} Sentinel-2 exports built for ${monthCount} ${monthLabel} × ${indexCount} ${indexLabel}`
-              : `${successful} Sentinel-2 exports available for ${monthCount} ${monthLabel} × ${indexCount} ${indexLabel}`;
-            setStatus(
-              `${completionPrefix}! ${summary}.${destinationNote}`,
-              'success'
-            );
-          }
+       fileInput.addEventListener('change', (event) => {
+         const file = event.target.files[0];
+         updateFileStatus(file ? file.name : 'No file chosen');
+       });
 
-          form.reset();
-        } catch (error) {
-          console.error('Export workflow failed', error);
-          const message = error instanceof Error ? error.message : String(error);
-          setStatus(`Export failed: ${message}`, 'error');
-        } finally {
-          submitButton.disabled = false;
-          isProcessing = false;
-        }
-      });
-    </script>
-  </body>
-</html>
+       form.addEventListener('submit', async (event) => {
+         event.preventDefault();
+         if (isProcessing) {
+           return;
+         }
+
+         if (!fileInput.files.length) {
+           setStatus('Please select a zipped shapefile bundle before submitting.', 'error');
+           fileUpload.focus();
+           return;
+         }
+
+         if (!form.reportValidity()) {
+           setStatus('Please complete the highlighted fields before submitting.', 'error');
+           return;
+         }
+
+         const selectedIndices = getIndicesCheckboxes()
+           .filter((checkbox) => checkbox.checked)
+           .map((checkbox) => checkbox.value);
+
+         if (!selectedIndices.length) {
+           setStatus('Select at least one vegetation index to export.', 'error');
+           const firstCheckbox = getIndicesCheckboxes()[0];
+           if (firstCheckbox) {
+             firstCheckbox.focus();
+           }
+           return;
+         }
+
+         let months;
+         try {
+           months = deriveMonths(startDateInput.value, endDateInput.value);
+         } catch (error) {
+           setStatus(error instanceof Error ? error.message : String(error), 'error');
+           return;
+         }
+
+         const apiKey = apiKeyInput.value.trim();
+         const headers = apiKey ? { 'x-api-key': apiKey } : {};
+         const exportTarget = exportDestinationSelect.value;
+         const aoiName = aoiNameInput.value.trim();
+         const monthCount = months.length;
+         const indexCount = selectedIndices.length;
+
+         setStatus('Uploading shapefile to prepare AOI geometry…', 'pending');
+         isProcessing = true;
+         setProcessingState(true);
+
+         try {
+           const aoiPayload = await uploadAndFetchGeometry(fileInput.files[0], aoiName, headers);
+           const { geometry, aoi_name: sanitizedAoiName } = aoiPayload;
+           const jobAoiName = sanitizedAoiName || aoiName;
+           if (sanitizedAoiName && sanitizedAoiName !== aoiName) {
+             console.info(`AOI name sanitised to "${sanitizedAoiName}" for export filenames.`);
+           }
+
+           setStatus('Queueing Sentinel-2 export job…', 'pending');
+
+           const queueResponse = await fetch(buildUrl('export/s2/indices'), {
+             method: 'POST',
+             headers: { ...headers, 'Content-Type': 'application/json' },
+             body: JSON.stringify({
+               aoi_geojson: geometry,
+               months,
+               indices: selectedIndices,
+               export_target: exportTarget,
+               aoi_name: jobAoiName,
+             }),
+           });
+
+           if (!queueResponse.ok) {
+             throw new Error(await readError(queueResponse));
+           }
+
+           const data = await queueResponse.json();
+           const jobId = data.job_id;
+           if (!jobId) {
+             throw new Error('Export job did not return an identifier.');
+           }
+
+           setStatus('Export job queued. Building composites…', 'pending');
+
+           const finalStatus = await pollJob(jobId, exportTarget, headers);
+
+           if (exportTarget === 'zip') {
+             setStatus('Exports ready. Preparing ZIP download…', 'pending');
+             await downloadZip(jobId, headers);
+           } else {
+             const summary = await fetchExportSummary(jobId, headers);
+             if (summary && Array.isArray(summary.items)) {
+               console.groupCollapsed('Sentinel-2 export destinations');
+               summary.items.forEach((item) => {
+                 const destination = item.signed_url || item.destination_uri || 'pending';
+                 console.log(`${item.month} ${item.index}: ${destination}`);
+               });
+               console.groupEnd();
+             } else {
+               console.info('Export summary', summary);
+             }
+           }
+
+           const items = Array.isArray(finalStatus.items) ? finalStatus.items : [];
+           const successful = items.filter((item) => item.status === 'completed').length;
+           const failed = items.filter((item) => item.status === 'failed').length;
+           const total = items.length;
+           const monthLabel = monthCount === 1 ? 'month' : 'months';
+           const indexLabel = indexCount === 1 ? 'index' : 'indices';
+           const destinationNote = exportTarget === 'zip' ? '' : ' Destinations have been logged to the browser console.';
+
+           if (failed > 0) {
+             const warningPrefix = exportTarget === 'zip' ? 'Download finished with warnings' : 'Exports finished with warnings';
+             setStatus(
+               `${warningPrefix}: ${successful} of ${total} exports succeeded (${failed} failed) across ${monthCount} ${monthLabel} × ${indexCount} ${indexLabel}.${destinationNote}`,
+               'success'
+             );
+           } else {
+             const completionPrefix = exportTarget === 'zip' ? 'Download complete' : 'Exports complete';
+             const summary = exportTarget === 'zip'
+               ? `${successful} Sentinel-2 exports built for ${monthCount} ${monthLabel} × ${indexCount} ${indexLabel}`
+               : `${successful} Sentinel-2 exports available for ${monthCount} ${monthLabel} × ${indexCount} ${indexLabel}`;
+             setStatus(
+               `${completionPrefix}! ${summary}.${destinationNote}`,
+               'success'
+             );
+           }
+
+           form.reset();
+           setDefaultDates();
+           updateFileStatus('No file chosen');
+           getIndicesCheckboxes().forEach((checkbox) => {
+             checkbox.checked = false;
+           });
+           const defaultCheckbox = document.getElementById('index-ndvi');
+           if (defaultCheckbox) {
+             defaultCheckbox.checked = true;
+           }
+         } catch (error) {
+           console.error('Export workflow failed', error);
+           const message = error instanceof Error ? error.message : String(error);
+           setStatus(`Export failed: ${message}`, 'error');
+         } finally {
+           isProcessing = false;
+           setProcessingState(false);
+         }
+       });
+     </script>
+   </body>
+ </html>
+
         """
     )
 


### PR DESCRIPTION
## Summary
- restyle the /ui export console with a card-based layout, refined typography, and clearer file/field helpers
- replace the index multi-select with scrollable checkboxes plus select-all/clear-all affordances while preserving available indices
- update the front-end workflow to drive the new controls, maintain status messaging, and restore sensible defaults after each run

## Testing
- pytest services/backend

------
https://chatgpt.com/codex/tasks/task_e_68d3da0f276c832790569615b15bed3b