### PR TITLE
Fix module resolution when starting from repo root

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,24 @@
+"""Proxy package so `import app` resolves to the backend service package.
+
+The actual FastAPI application lives under ``services/backend/app``. Platforms
+like Render import ``app.main`` from the repository root, which previously
+failed with ``ModuleNotFoundError``. By customising ``__path__`` we delegate all
+submodule lookups to the real package without duplicating code or adjusting
+start commands.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_backend_package = (
+    Path(__file__).resolve().parent.parent / "services" / "backend" / "app"
+)
+
+if not _backend_package.is_dir():
+    raise ImportError(
+        "The backend application package was not found at"
+        f" {_backend_package!s}."
+    )
+
+__path__ = [str(_backend_package)]
+__file__ = str(_backend_package / "__init__.py")

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,19 @@
+"""Ensure the backend service package is importable from the repository root.
+
+Render and other PaaS providers often run the start command from the repo root,
+which means the `services/backend` directory containing the FastAPI package is
+not automatically on `sys.path`. By inserting it here we allow `uvicorn
+app.main:app` (and similar entrypoints) to resolve correctly without requiring
+manual PYTHONPATH tweaks.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).resolve().parent / "services" / "backend"
+
+if _BACKEND_DIR.is_dir():
+    backend_path = str(_BACKEND_DIR)
+    if backend_path not in sys.path:
+        sys.path.insert(0, backend_path)


### PR DESCRIPTION
## Summary
- add a lightweight proxy package so `import app` resolves to the FastAPI backend when run from the repository root
- include a `sitecustomize` shim that prepends `services/backend` to `sys.path` for tooling that honours it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3e6b646dc8327b372451bb012afa9