### PR TITLE
Add production zone exports to Sentinel-2 workflow

### DIFF
--- a/services/backend/tests/test_exports_registry.py
+++ b/services/backend/tests/test_exports_registry.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import shutil
+import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+
+TEST_DIR = Path(__file__).resolve().parent
+BACKEND_DIR = TEST_DIR.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
 
 from app import exports
 from app.api import s2_indices


### PR DESCRIPTION
## Summary
- add optional production zone configuration to the Sentinel-2 export endpoint
- extend the export orchestrator to build and deliver production zone rasters, vectors, and stats within a zones/ prefix
- update zone services and tests to cover geometry inputs and the new workflow

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d715725adc8327b2795f9dbff7b899