### PR TITLE
Fix production zone simplification parameters

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -268,7 +268,7 @@ def _simplify_vectors(vectors: ee.FeatureCollection, tolerance_m: float) -> ee.F
         return vectors
 
     def _simplify(feature: ee.Feature) -> ee.Feature:
-        geom = feature.geometry().simplify(maxError=tolerance_m, preserveTopology=True)
+        geom = feature.geometry().simplify(maxError=tolerance_m)
         zone_value = ee.Number(feature.get("zone")).toInt()
         return feature.setGeometry(geom).set({"zone": zone_value, "zone_id": zone_value})
 


### PR DESCRIPTION
## Summary
- remove the unsupported `preserveTopology` argument from production zone geometry simplification so the Earth Engine call succeeds

## Testing
- PYTHONPATH=. pytest tests/test_zones.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dba4e3ed408327b28be61da7cfa81b