### PR TITLE
Improve stability threshold fallback metadata

### DIFF
--- a/services/backend/app/api/zones.py
+++ b/services/backend/app/api/zones.py
@@ -122,6 +122,10 @@ def create_production_zones(request: ProductionZonesRequest):
         "metadata": metadata,
     }
 
+    debug_info = result.get("debug") or metadata.get("debug")
+    if debug_info:
+        response["debug"] = debug_info
+
     if request.export_target == "gcs":
         response["bucket"] = result.get("bucket")
         response["prefix"] = result.get("prefix")


### PR DESCRIPTION
## Summary
- add iterative stability threshold evaluation with survivability metadata and low confidence flag
- expose stability diagnostics in export metadata and API debug payloads
- extend zone service tests to cover threshold fallbacks and low confidence reporting

## Testing
- PYTHONPATH=services/backend pytest services/backend/tests/test_zones.py


------
https://chatgpt.com/codex/tasks/task_e_68dbc459eccc8327b712433590b2f40b