### PR TITLE
Respect GEE bucket override in GCS service

### DIFF
--- a/services/backend/app/services/gcs.py
+++ b/services/backend/app/services/gcs.py
@@ -2,14 +2,18 @@ import os, json
 from google.cloud import storage
 from datetime import timedelta
 
+
+def _bucket_name() -> str:
+    name = (os.environ.get("GEE_GCS_BUCKET") or os.environ.get("GCS_BUCKET") or "").strip()
+    if not name:
+        raise RuntimeError("GEE_GCS_BUCKET or GCS_BUCKET env vars are required for GCS access")
+    return name
+
 def _client():
     return storage.Client()
 
 def _bucket():
-    name = os.environ.get("GCS_BUCKET")
-    if not name:
-        raise RuntimeError("GCS_BUCKET env var is required")
-    return _client().bucket(name)
+    return _client().bucket(_bucket_name())
 
 def upload_json(data: dict, path: str, content_type: str = "application/json") -> str:
     bucket = _bucket()

--- a/services/backend/tests/test_gcs.py
+++ b/services/backend/tests/test_gcs.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from app.services import gcs
+
+
+class _FakeBucket:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakeClient:
+    def __init__(self):
+        self.requested_name: str | None = None
+
+    def bucket(self, name: str):
+        self.requested_name = name
+        return _FakeBucket(name)
+
+
+def test_bucket_prefers_gee_env(monkeypatch):
+    monkeypatch.delenv("GCS_BUCKET", raising=False)
+    monkeypatch.setenv("GEE_GCS_BUCKET", "gee-primary")
+
+    fake_client = _FakeClient()
+    monkeypatch.setattr(gcs, "_client", lambda: fake_client)
+
+    bucket = gcs._bucket()
+
+    assert isinstance(bucket, _FakeBucket)
+    assert bucket.name == "gee-primary"
+    assert fake_client.requested_name == "gee-primary"
+
+
+def test_bucket_requires_configuration(monkeypatch):
+    monkeypatch.delenv("GEE_GCS_BUCKET", raising=False)
+    monkeypatch.delenv("GCS_BUCKET", raising=False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        gcs._bucket_name()
+
+    assert "GEE_GCS_BUCKET or GCS_BUCKET" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- resolve the Cloud Storage bucket name with a helper that prefers GEE_GCS_BUCKET and errors when unset
- add unit coverage for the GEE-specific bucket configuration path

## Testing
- pytest tests/test_gcs.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd570a3a48327bccec39b458c793b