### PR TITLE
Use shared bucket helper for NDVI links

### DIFF
--- a/services/backend/app/api/routes.py
+++ b/services/backend/app/api/routes.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, get_args
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 import ee, os
-from app.services.gcs import download_json, exists, sign_url
+from app.services.gcs import bucket_name, download_json, exists, sign_url
 from app.services.indices import SUPPORTED_INDICES
 from app.services.ndvi import (
     DEFAULT_COLLECTION,
@@ -129,10 +129,17 @@ def ndvi_years(field_id: str, index: SupportedIndex = Query("ndvi")):
 def ndvi_links(field_id: str, year: int, index: SupportedIndex = Query("ndvi")):
     json_path = gcs_index_path(index, field_id, year)
     csv_path = gcs_index_csv_path(index, field_id, year)
+    bucket = bucket_name()
     return {
         "index": index,
-        "json": {"gs": f"gs://{os.getenv('GCS_BUCKET')}/{json_path}", "signed": sign_url(json_path)},
-        "csv":  {"gs": f"gs://{os.getenv('GCS_BUCKET')}/{csv_path}",  "signed": sign_url(csv_path)}
+        "json": {
+            "gs": f"gs://{bucket}/{json_path}",
+            "signed": sign_url(json_path),
+        },
+        "csv": {
+            "gs": f"gs://{bucket}/{csv_path}",
+            "signed": sign_url(csv_path),
+        },
     }
 
 router.include_router(export_router, prefix="/export", tags=["export"])

--- a/services/backend/app/services/gcs.py
+++ b/services/backend/app/services/gcs.py
@@ -5,11 +5,14 @@ from datetime import timedelta
 def _client():
     return storage.Client()
 
-def _bucket():
-    name = os.environ.get("GCS_BUCKET")
+def bucket_name() -> str:
+    name = os.environ.get("GEE_GCS_BUCKET") or os.environ.get("GCS_BUCKET")
     if not name:
-        raise RuntimeError("GCS_BUCKET env var is required")
-    return _client().bucket(name)
+        raise RuntimeError("GEE_GCS_BUCKET or GCS_BUCKET env var is required")
+    return name
+
+def _bucket():
+    return _client().bucket(bucket_name())
 
 def upload_json(data: dict, path: str, content_type: str = "application/json") -> str:
     bucket = _bucket()

--- a/services/backend/tests/test_ndvi_monthly.py
+++ b/services/backend/tests/test_ndvi_monthly.py
@@ -230,3 +230,16 @@ def test_cache_paths_and_payload(monkeypatch):
         },
         "data": [{"month": 1, "gndvi": 0.42}],
     }
+
+
+def test_ndvi_links_uses_gee_bucket(monkeypatch):
+    monkeypatch.delenv("GCS_BUCKET", raising=False)
+    monkeypatch.setenv("GEE_GCS_BUCKET", "gee-only")
+    monkeypatch.setattr(routes, "sign_url", lambda path: f"signed://{path}")
+
+    response = routes.ndvi_links("field-7", 2023, index="ndvi")
+
+    assert response["json"]["gs"] == "gs://gee-only/index-results/ndvi/field-7/2023.json"
+    assert response["json"]["signed"] == "signed://index-results/ndvi/field-7/2023.json"
+    assert response["csv"]["gs"] == "gs://gee-only/index-results/ndvi/field-7/2023.csv"
+    assert response["csv"]["signed"] == "signed://index-results/ndvi/field-7/2023.csv"


### PR DESCRIPTION
## Summary
- expose a shared bucket_name helper that falls back to GEE_GCS_BUCKET
- update the /ndvi/links endpoint to build gs:// URLs with the shared helper
- add a regression test covering the GEE bucket fallback for NDVI links

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd571fa088327b1d3e8553bd5501a