### PR TITLE
Expose zone palette metadata for zone previews

### DIFF
--- a/services/backend/app/api/zones.py
+++ b/services/backend/app/api/zones.py
@@ -162,6 +162,11 @@ def create_production_zones(request: ProductionZonesRequest):
     ym_start = used_months[0]
     ym_end = used_months[-1]
 
+    palette = result.get("palette") or metadata.get("palette") if isinstance(metadata, dict) else None
+    thresholds = result.get("thresholds") or (
+        metadata.get("percentile_thresholds") if isinstance(metadata, dict) else None
+    )
+
     response = {
         "ok": True,
         "ym_start": ym_start,
@@ -170,6 +175,11 @@ def create_production_zones(request: ProductionZonesRequest):
         "tasks": result.get("tasks", {}),
         "metadata": metadata,
     }
+
+    if palette is not None:
+        response["palette"] = palette
+    if thresholds is not None:
+        response["thresholds"] = thresholds
 
     debug_info = result.get("debug") or metadata.get("debug")
     stability_meta = {}


### PR DESCRIPTION
## Summary
- add a Sentinel-2 zone palette constant and capture percentile thresholds during zone classification
- switch the cleanup pipeline to meter-based smoothing/open/close operations and attach area metadata when vectorising
- surface the palette/thresholds through the zone API response and extend tests to cover the new behaviour

## Testing
- `cd services/backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dcb124620c832796535ec454c67c8a