### PR TITLE
Support date inputs for production zone exports

### DIFF
--- a/services/backend/tests/test_exports_registry.py
+++ b/services/backend/tests/test_exports_registry.py
@@ -580,6 +580,8 @@ def test_zone_artifacts_use_raw_geojson_for_mmu(tmp_path, monkeypatch):
         aoi_name,
         months,
         *,
+        start_date=None,
+        end_date=None,
         geometry=None,
         **kwargs,
     ):


### PR DESCRIPTION
### **User description**
## Summary
- allow production zone requests to supply start_date/end_date values while keeping month payloads backwards compatible
- teach the zone service to resolve date spans, generate month lists, and continue surfacing palette/threshold metadata
- extend the zone test suite to cover mixed input modes and ensure downstream integrations receive the resolved dates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcba1b9b448327a652eca083adb122


___

### **PR Type**
Enhancement


___

### **Description**
- Add date range support to production zone exports

- Maintain backward compatibility with existing month inputs

- Extend validation to handle three input modes

- Update service layer to resolve dates and generate months


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProductionZonesRequest"] --> B["Input Validation"]
  B --> C["Date Resolution"]
  C --> D["Month Generation"]
  D --> E["Zone Service Export"]
  B --> F["Three Input Modes"]
  F --> G["months[]"]
  F --> H["start_month/end_month"]
  F --> I["start_date/end_date"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Add date fields and validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/zones.py

<ul><li>Add <code>start_date</code> and <code>end_date</code> fields to ProductionZonesRequest<br> <li> Implement comprehensive validation for three input modes<br> <li> Generate month lists from date ranges<br> <li> Pass resolved dates to zone service</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/86/files#diff-ce9cf976c51711c682b99a9915e725bc40fa95796fa0c248a660e1d583661964">+98/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Extend zone service with date support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Add date parameters to export functions<br> <li> Implement date-to-month conversion utilities<br> <li> Update composite series building with date bounds<br> <li> Enhance metadata with inclusive end dates</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/86/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+70/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_exports_registry.py</strong><dd><code>Update test mock signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_exports_registry.py

- Update mock function signature with date parameters


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/86/files#diff-3df5cf880bd9ca1623a8e6fb5c6be240bc60cd1427c8a76dcb5470c992383c5c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_zones.py</strong><dd><code>Add comprehensive date input tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones.py

<ul><li>Add comprehensive tests for date input validation<br> <li> Test date range to month conversion<br> <li> Verify backward compatibility with existing inputs<br> <li> Update mock functions with date parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/86/files#diff-ca8cea705525d0ea55f6f1fdbb1c8b8ca6a132ee059d07ba59dceed9f2a6392e">+76/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

