### PR TITLE
Fix percentile zone classification iterate

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -651,7 +651,7 @@ def _classify_by_percentiles(
         gt_band = image.gt(t)
         return current_img.add(gt_band)
 
-    summed = ee.Image(thresholds).iterate(_accumulate, zero)
+    summed = ee.List(thresholds).iterate(_accumulate, zero)
     classified = ee.Image(summed).add(1).toInt()
 
     return classified.rename("zone"), thresholds


### PR DESCRIPTION
## Summary
- adjust NDVI percentile classification to iterate threshold sums via ee.List
- add regression test to ensure percentile classification uses the list iterate helper

## Testing
- PYTHONPATH=. pytest tests/test_zones.py

------
https://chatgpt.com/codex/tasks/task_e_68de02f4c99483278132ae6ab82b4f74