### PR TITLE
Normalize zone export parameter handling

### DIFF
--- a/services/backend/app/api/zones.py
+++ b/services/backend/app/api/zones.py
@@ -229,26 +229,28 @@ def create_production_zones(request: ProductionZonesRequest):
                 detail="A GCS bucket must be provided when export_target is 'gcs'.",
             )
 
+    destination = request.export_target
+
     try:
         result = zone_service.export_selected_period_zones(
             request.aoi_geojson,
-            request.aoi_name,
-            request.months,
+            months=request.months,
+            aoi_name=request.aoi_name,
+            destination=destination,
             start_date=request.start_date,
             end_date=request.end_date,
             cloud_prob_max=request.cloud_prob_max,
             n_classes=request.n_classes,
             cv_mask_threshold=request.cv_mask_threshold,
-            mmu_ha=request.mmu_ha,
+            min_mapping_unit_ha=request.mmu_ha,
             smooth_radius_m=request.smooth_radius_m,
             open_radius_m=request.open_radius_m,
             close_radius_m=request.close_radius_m,
-            simplify_tol_m=request.simplify_tol_m,
+            simplify_tolerance_m=request.simplify_tol_m,
             simplify_buffer_m=request.simplify_buffer_m,
-            export_target=request.export_target,
             gcs_bucket=resolved_bucket,
             gcs_prefix=request.gcs_prefix,
-            include_zonal_stats=request.include_zonal_stats,
+            include_stats=request.include_zonal_stats,
             apply_stability_mask=request.apply_stability_mask,
         )
     except ValueError as exc:

--- a/services/backend/app/exports.py
+++ b/services/backend/app/exports.py
@@ -595,21 +595,21 @@ def _build_zone_artifacts_for_job(job: ExportJob) -> None:
     try:
         result = zone_service.export_selected_period_zones(
             job.aoi_geojson,
-            job.aoi_name,
-            job.months,
+            months=job.months,
+            aoi_name=job.aoi_name,
             geometry=job.geometry,
             cloud_prob_max=job.cloud_prob_max,
             n_classes=job.zone_config.n_classes,
             cv_mask_threshold=job.zone_config.cv_mask_threshold,
             apply_stability_mask=job.zone_config.apply_stability_mask,
-            mmu_ha=job.zone_config.min_mapping_unit_ha,
+            min_mapping_unit_ha=job.zone_config.min_mapping_unit_ha,
             smooth_radius_m=job.zone_config.smooth_radius_m,
             open_radius_m=job.zone_config.open_radius_m,
             close_radius_m=job.zone_config.close_radius_m,
-            simplify_tol_m=job.zone_config.simplify_tolerance_m,
+            simplify_tolerance_m=job.zone_config.simplify_tolerance_m,
             simplify_buffer_m=job.zone_config.simplify_buffer_m,
-            export_target="zip",
-            include_zonal_stats=job.zone_config.include_stats,
+            destination="zip",
+            include_stats=job.zone_config.include_stats,
         )
         artifacts = result.get("artifacts")
         metadata = result.get("metadata", {}) or {}

--- a/services/backend/tests/test_exports_registry.py
+++ b/services/backend/tests/test_exports_registry.py
@@ -576,17 +576,23 @@ def test_zone_artifacts_use_raw_geojson_for_mmu(tmp_path, monkeypatch):
     )
 
     def fake_export_selected_period_zones(
-        aoi_geojson,
-        aoi_name,
-        months,
+        aoi_geojson_or_geom,
         *,
-        start_date=None,
-        end_date=None,
+        months,
+        aoi_name,
+        destination,
         geometry=None,
+        min_mapping_unit_ha,
+        include_stats=True,
+        simplify_tolerance_m=5,
         **kwargs,
     ):
-        captured["aoi_geojson"] = aoi_geojson
+        captured["aoi_geojson"] = aoi_geojson_or_geom
         captured["geometry"] = geometry
+        captured["destination"] = destination
+        captured["min_mapping_unit_ha"] = min_mapping_unit_ha
+        captured["include_stats"] = include_stats
+        captured["simplify_tolerance_m"] = simplify_tolerance_m
         captured["kwargs"] = kwargs
         return {
             "artifacts": artifacts,
@@ -636,7 +642,8 @@ def test_zone_artifacts_use_raw_geojson_for_mmu(tmp_path, monkeypatch):
     assert job.zone_state.metadata.get("mmu_applied") is False
     assert captured["aoi_geojson"] is job.aoi_geojson
     assert captured["geometry"] is geometry_sentinel
-    assert captured["kwargs"]["mmu_ha"] == job.zone_config.min_mapping_unit_ha
+    assert captured["destination"] == "zip"
+    assert captured["min_mapping_unit_ha"] == job.zone_config.min_mapping_unit_ha
 
     exports._process_zip_exports(job)
 


### PR DESCRIPTION
### **User description**
## Summary
- update the zones service to normalise legacy parameter aliases, expose zone artifacts in the result payload, and bridge to the legacy helpers
- adjust the production zones API and background export runner to use the new keyword arguments and destination handling
- expand the zone-related tests to cover the production endpoint, Sentinel-2 job integration, and the stability-mask fallback with the new service surface

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de715e445c8327adef195345363ed4


___

### **PR Type**
Enhancement


___

### **Description**
- Normalize zone export parameter handling with legacy aliases

- Update API endpoints to use new keyword arguments

- Expand test coverage for production endpoints and Sentinel-2 integration

- Bridge to legacy helpers for backward compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  API["API Endpoints"] -- "normalize params" --> Service["Zone Service"]
  Service -- "bridge to" --> Legacy["Legacy Helpers"]
  Service -- "return artifacts" --> Export["Export Results"]
  Tests["Enhanced Tests"] -- "validate" --> API
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Normalize API parameter handling for zone exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/api/zones.py

<ul><li>Update <code>create_production_zones</code> to use keyword arguments for zone <br>service call<br> <li> Change parameter names from legacy format (<code>mmu_ha</code> to <br><code>min_mapping_unit_ha</code>, <code>simplify_tol_m</code> to <code>simplify_tolerance_m</code>)<br> <li> Add <code>destination</code> parameter extraction from <code>export_target</code><br> <li> Update <code>include_zonal_stats</code> to <code>include_stats</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/105/files#diff-ce9cf976c51711c682b99a9915e725bc40fa95796fa0c248a660e1d583661964">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exports.py</strong><dd><code>Update export job parameter normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/exports.py

<ul><li>Update <code>_build_zone_artifacts_for_job</code> to use normalized parameter names<br> <li> Change <code>export_target</code> to <code>destination</code> parameter<br> <li> Update legacy parameter aliases (<code>mmu_ha</code>, <code>simplify_tol_m</code>, <br><code>include_zonal_stats</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/105/files#diff-b58e5436743b0f53bc46154af4ec1a7ddaf5f13cbe9a90df7b87efdafa94fe4c">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Major zone service parameter normalization and legacy bridging</code></dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Add comprehensive parameter normalization with legacy alias support<br> <li> Implement destination-specific export handling (drive, gcs, zip)<br> <li> Add legacy wrapper functions for backward compatibility<br> <li> Expand result payload with artifacts, paths, and metadata<br> <li> Add GCS prefix handling and path construction logic</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/105/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+289/-66</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_exports_registry.py</strong><dd><code>Update export registry tests for normalized parameters</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_exports_registry.py

<ul><li>Update mock function signature to match new parameter structure<br> <li> Add validation for normalized parameters (<code>destination</code>, <br><code>min_mapping_unit_ha</code>, <code>include_stats</code>)<br> <li> Capture additional parameters for test validation</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/105/files#diff-3df5cf880bd9ca1623a8e6fb5c6be240bc60cd1427c8a76dcb5470c992383c5c">+14/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_zones.py</strong><dd><code>Expand zone tests with production endpoint coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones.py

<ul><li>Add comprehensive test for production zones endpoint with HTTP <br>integration<br> <li> Update mock functions to use normalized parameter signatures<br> <li> Add parameter validation assertions for API calls<br> <li> Expand test coverage for different request types and destinations</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/105/files#diff-ca8cea705525d0ea55f6f1fdbb1c8b8ca6a132ee059d07ba59dceed9f2a6392e">+174/-18</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_zones_mask.py</strong><dd><code>Update zone mask tests for new artifact structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones_mask.py

<ul><li>Update mock functions to match new <code>build_zone_artifacts</code> signature<br> <li> Add property handling for fake zone image objects<br> <li> Adjust test setup for normalized parameter structure</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/105/files#diff-c8a2bf600c61e2fe0d301ca3f21c92fdffe0b255ae548e664c57237d7f279141">+39/-34</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

