### PR TITLE
Ensure Earth Engine index aggregation returns images

### DIFF
--- a/services/backend/tests/test_tiles_indices.py
+++ b/services/backend/tests/test_tiles_indices.py
@@ -31,6 +31,7 @@ def test_gndvi_images_and_metadata(monkeypatch):
     )
 
     assert isinstance(annual, FakeMeanImage)
+    assert hasattr(annual, "clip")
     assert annual.clamped_to == (-1.0, 1.0)
     assert annual.value == pytest.approx(0.6)
 
@@ -48,6 +49,7 @@ def test_gndvi_images_and_metadata(monkeypatch):
     )
 
     assert isinstance(month, FakeMeanImage)
+    assert hasattr(month, "clip")
     assert month.clamped_to == (-1.0, 1.0)
     assert month.value == pytest.approx(1.0)
 


### PR DESCRIPTION
## Summary
- coerce export and tile index mapping callbacks to operate on ee.Image instances and cast the aggregated mean before clipping
- update the fake Earth Engine tests to wrap only aggregated images and assert the mean result still exposes clip

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df8b4ddc948327978ba2624bd01dad