### PR TITLE
Support additional keyword aliases for zone exports

### DIFF
--- a/services/backend/tests/test_exports_registry.py
+++ b/services/backend/tests/test_exports_registry.py
@@ -599,6 +599,7 @@ def test_zone_artifacts_use_raw_geojson_for_mmu(tmp_path, monkeypatch):
             "metadata": {
                 "used_months": list(months),
                 "skipped_months": [],
+                "min_mapping_unit_applied": False,
                 "mmu_applied": False,
             },
             "prefix": "zones/PROD_202401_202401_tiny_field_zones",
@@ -639,6 +640,7 @@ def test_zone_artifacts_use_raw_geojson_for_mmu(tmp_path, monkeypatch):
     exports._build_zone_artifacts_for_job(job)
 
     assert job.zone_state is not None
+    assert job.zone_state.metadata.get("min_mapping_unit_applied") is False
     assert job.zone_state.metadata.get("mmu_applied") is False
     assert captured["aoi_geojson"] is job.aoi_geojson
     assert captured["geometry"] is geometry_sentinel


### PR DESCRIPTION
## Summary
- normalize new min_mapping_unit_ha, simplify_tolerance_m, and destination keyword arguments when exporting zones
- propagate the min_mapping_unit_applied flag in metadata and add a guarded Earth Engine initialization fallback for tests
- cover the new aliases with unit tests and update registry checks for the expanded metadata

## Testing
- `GEE_ALLOW_INIT_FAILURE=1 PYTHONPATH=. pytest tests/test_zones.py::test_export_selected_period_zones_accepts_new_keywords tests/test_exports_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68df9a5f93548327ba2f2d5b865ba33d