### PR TITLE
Append backend path so installed packages take precedence

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -2,9 +2,10 @@
 
 Render and other PaaS providers often run the start command from the repo root,
 which means the `services/backend` directory containing the FastAPI package is
-not automatically on `sys.path`. By inserting it here we allow `uvicorn
+not automatically on `sys.path`. By appending it here we allow `uvicorn
 app.main:app` (and similar entrypoints) to resolve correctly without requiring
-manual PYTHONPATH tweaks.
+manual PYTHONPATH tweaks while keeping system-installed packages ahead of the
+repository modules.
 """
 from __future__ import annotations
 
@@ -16,4 +17,4 @@ _BACKEND_DIR = Path(__file__).resolve().parent / "services" / "backend"
 if _BACKEND_DIR.is_dir():
     backend_path = str(_BACKEND_DIR)
     if backend_path not in sys.path:
-        sys.path.insert(0, backend_path)
+        sys.path.append(backend_path)


### PR DESCRIPTION
### **User description**
## Summary
- append the services/backend directory to sys.path in sitecustomize.py instead of inserting at position 0
- update the accompanying documentation string to note that system-installed packages remain ahead of repository modules

## Testing
- pytest services/backend/tests/test_zones.py

------
https://chatgpt.com/codex/tasks/task_e_68e095cc07888327b0c101da733f2593


___

### **PR Type**
Enhancement


___

### **Description**
- Change backend path insertion from `insert(0)` to `append()`

- Prioritize system-installed packages over repository modules

- Update documentation to reflect new path ordering behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sys.path.insert(0)"] -- "changed to" --> B["sys.path.append()"]
  B --> C["System packages prioritized"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sitecustomize.py</strong><dd><code>Modify path insertion order for package precedence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sitecustomize.py

<ul><li>Changed <code>sys.path.insert(0, backend_path)</code> to <br><code>sys.path.append(backend_path)</code><br> <li> Updated docstring to clarify system packages take precedence<br> <li> Modified comment from "inserting" to "appending"</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/119/files#diff-1dc3332b767b1b60ea953e5dfdd81df90bf3449d9c313c945bbdb29e78f45ff8">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

