### PR TITLE
Fix NDVI zone classification lower bound handling

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -303,7 +303,12 @@ def _classify_local_zones(
                 "Unable to derive strictly increasing NDVI thresholds for zone classification."
             )
 
-    classified = np.digitize(ndvi.filled(np.nan), thresholds, right=False).astype(np.int16) + 1
+    # ``np.digitize`` defaults to ``right=False`` which excludes the lower bound of each bin
+    # (assigning exact matches to the next class). When the first percentile equals the
+    # minimum NDVI value this behaviour empties class 1, which later results in a
+    # "fewer zones than requested" error. Including the lower bound keeps the percentile
+    # classes contiguous and ensures the first class remains populated.
+    classified = np.digitize(ndvi.filled(np.nan), thresholds, right=True).astype(np.int16) + 1
     classified[ndvi.mask] = 0
 
     pixel_size_x = abs(transform.a)


### PR DESCRIPTION
### **User description**
## Summary
- ensure local zone classification treats percentile thresholds as inclusive of the lower bound to retain the minimum class
- add a regression test covering NDVI rasters whose first percentile matches the minimum value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1ce0f84448327876767c1b77f92c3


___

### **PR Type**
Bug fix


___

### **Description**
- Fix NDVI zone classification to include lower bound values

- Prevent empty first class when percentile equals minimum

- Add regression test for edge case scenario


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NDVI Raster"] --> B["np.digitize with right=True"]
  B --> C["Classified Zones"]
  D["Percentile Thresholds"] --> B
  E["Regression Test"] --> F["Validates Minimum Class"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Fix digitize bounds to include minimum values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Change <code>np.digitize</code> parameter from <code>right=False</code> to <code>right=True</code><br> <li> Add detailed comment explaining the lower bound inclusion fix<br> <li> Ensure minimum NDVI values are assigned to first class</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/125/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_zones.py</strong><dd><code>Add regression test for minimum class handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones.py

<ul><li>Add optional <code>data</code> parameter to <code>_write_ndvi_raster</code> helper function<br> <li> Create new test <br><code>test_classify_local_zones_includes_minimum_in_first_class</code><br> <li> Test edge case where first percentile equals minimum NDVI value</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/125/files#diff-ca8cea705525d0ea55f6f1fdbb1c8b8ca6a132ee059d07ba59dceed9f2a6392e">+41/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

