### PR TITLE
Fix zone majority fill outside AOI and add regression test

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -471,6 +471,7 @@ def _classify_local_zones(
 
     ndvi_data = ndvi.filled(np.nan)
     combined_mask = np.ma.getmaskarray(ndvi) | np.isnan(ndvi_data)
+    valid_mask = ~combined_mask
     if combined_mask.all():
         raise ValueError(NDVI_MASK_EMPTY_ERROR)
 
@@ -658,9 +659,10 @@ def _classify_local_zones(
         classified = classified.astype(np.uint8)
 
     if np.any(classified == 0):
-        filled = _majority_filter(classified, 1)
-        zero_mask = classified == 0
-        classified[zero_mask] = filled[zero_mask]
+        fill_mask = valid_mask & (classified == 0)
+        if np.any(fill_mask):
+            filled = _majority_filter(classified, 1)
+            classified[fill_mask] = filled[fill_mask]
     unique_zones = np.unique(classified[classified > 0])
 
     def _hex_to_rgba(value: str) -> tuple[int, int, int, int]:


### PR DESCRIPTION
### **User description**
## Summary
- capture the valid raster mask before smoothing and only fill interior gaps when classifying zones
- add a regression test that exercises masked borders to ensure rasters and vectors stay inside the AOI

## Testing
- pytest tests/test_zones.py

------
https://chatgpt.com/codex/tasks/task_e_68e20747c46883279ce8999e0a3a7014


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix zone majority fill to only operate within valid AOI boundaries

- Add regression test for masked border preservation

- Prevent zone classification from extending outside area of interest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NDVI Data"] --> B["Extract Valid Mask"]
  B --> C["Zone Classification"]
  C --> D["Majority Fill with Valid Mask"]
  D --> E["Zones Stay Within AOI"]
  F["Regression Test"] --> G["Verify Border Preservation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Fix majority fill to respect AOI boundaries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Capture valid raster mask before smoothing operations<br> <li> Apply majority fill only within valid mask boundaries<br> <li> Prevent zone classification from extending outside AOI</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/133/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_zones.py</strong><dd><code>Add regression test for border preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones.py

<ul><li>Add test with masked border data (nodata values on edges)<br> <li> Verify classified raster preserves nodata borders<br> <li> Check vector geometries stay within expected bounds<br> <li> Validate final zone count matches expected value</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/133/files#diff-ca8cea705525d0ea55f6f1fdbb1c8b8ca6a132ee059d07ba59dceed9f2a6392e">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

