### PR TITLE
Support ndvi_kmeans zone method selection

### DIFF
--- a/services/backend/tests/test_exports_registry.py
+++ b/services/backend/tests/test_exports_registry.py
@@ -594,6 +594,7 @@ def test_zone_artifacts_use_raw_geojson_for_mmu(tmp_path, monkeypatch):
         min_mapping_unit_ha,
         include_stats=True,
         simplify_tolerance_m=5,
+        method=zones.DEFAULT_METHOD,
         **kwargs,
     ):
         captured["aoi_geojson"] = aoi_geojson_or_geom
@@ -602,6 +603,7 @@ def test_zone_artifacts_use_raw_geojson_for_mmu(tmp_path, monkeypatch):
         captured["min_mapping_unit_ha"] = min_mapping_unit_ha
         captured["include_stats"] = include_stats
         captured["simplify_tolerance_m"] = simplify_tolerance_m
+        captured["method"] = method
         artifacts = _write_artifacts(tmp_path / "mmu_artifacts")
         return {
             "artifacts": artifacts,


### PR DESCRIPTION
## Summary
- honor the requested zone classification method when exporting selected period zones and accept ndvi_kmeans
- ensure metadata still exposes palette/threshold values for the new method while normalising zone_method reporting
- extend tests and fakes to cover the new method selection behaviour

## Testing
- `pytest tests/test_zones.py::test_export_selected_period_zones_preserves_thresholds_for_kmeans -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_68e22113663c8327bf731fb9eac8651f