### PR TITLE
Include mean NDVI artifacts in zone exports

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -134,6 +134,7 @@ class ZoneArtifacts:
     """Container for locally generated zone artefacts stored on disk."""
 
     raster_path: str
+    mean_ndvi_path: str
     vector_path: str
     vector_components: dict[str, str]
     zonal_stats_path: str | None = None
@@ -328,6 +329,7 @@ def _assemble_zone_artifacts(
     working_dir: Path,
     include_stats: bool,
     raster_path: Path,
+    mean_ndvi_path: Path,
     smoothing_requested: Mapping[str, float],
     applied_operations: Mapping[str, bool],
     executed_operations: Mapping[str, bool],
@@ -475,6 +477,7 @@ def _assemble_zone_artifacts(
 
     artifacts = ZoneArtifacts(
         raster_path=str(raster_path),
+        mean_ndvi_path=str(mean_ndvi_path),
         vector_path=str(shp_path),
         vector_components=vector_components,
         zonal_stats_path=str(stats_path) if stats_path is not None else None,
@@ -755,6 +758,7 @@ def _classify_local_zones(
         working_dir=working_dir,
         include_stats=include_stats,
         raster_path=raster_path,
+        mean_ndvi_path=ndvi_raster,
         smoothing_requested=smoothing_requested,
         applied_operations=applied_operations,
         executed_operations=executed_operations,
@@ -2234,6 +2238,7 @@ def _prepare_selected_period_artifacts(
             working_dir=workdir,
             include_stats=include_stats,
             raster_path=zone_raster_path,
+            mean_ndvi_path=ndvi_path,
             smoothing_requested=smoothing_requested,
             applied_operations=applied_operations,
             executed_operations=executed_operations,
@@ -2333,6 +2338,7 @@ def _prepare_selected_period_artifacts(
         working_dir=workdir,
         include_stats=include_stats,
         raster_path=zone_raster_path,
+        mean_ndvi_path=ndvi_path,
         smoothing_requested=smoothing_requested,
         applied_operations=applied_operations,
         executed_operations=executed_operations,
@@ -2594,6 +2600,7 @@ def export_selected_period_zones(
     result: Dict[str, object] = {
         "paths": {
             "raster": artifacts.raster_path,
+            "mean_ndvi": artifacts.mean_ndvi_path,
             "vectors": artifacts.vector_path,
             "vector_components": artifacts.vector_components,
             "zonal_stats": artifacts.zonal_stats_path if include_stats_flag else None,

--- a/services/backend/tests/test_zones.py
+++ b/services/backend/tests/test_zones.py
@@ -214,6 +214,7 @@ def test_classify_local_zones_generates_outputs(tmp_path: Path) -> None:
     )
 
     assert Path(artifacts.raster_path).exists()
+    assert Path(artifacts.mean_ndvi_path).exists()
     assert Path(artifacts.vector_path).exists()
     assert artifacts.vector_components
     assert artifacts.zonal_stats_path is not None
@@ -265,6 +266,7 @@ def test_prepare_selected_period_artifacts_percentiles(monkeypatch, tmp_path: Pa
         stats.write_text("")
         artifacts = zones.ZoneArtifacts(
             raster_path=str(raster),
+            mean_ndvi_path=str(ndvi_path),
             vector_path=str(vector),
             vector_components={"shp": str(vector)},
             zonal_stats_path=str(stats),
@@ -319,6 +321,8 @@ def test_prepare_selected_period_artifacts_percentiles(monkeypatch, tmp_path: Pa
     assert metadata["classification_method"] == "percentiles"
     assert metadata["stability_mask_applied"] is True
     assert Path(artifacts.raster_path).exists()
+    assert Path(artifacts.mean_ndvi_path).exists()
+    assert metadata["downloaded_mean_ndvi"] == artifacts.mean_ndvi_path
 
 
 def test_prepare_selected_period_artifacts_ndvi_kmeans(monkeypatch, tmp_path: Path) -> None:
@@ -448,6 +452,8 @@ def test_prepare_selected_period_artifacts_ndvi_kmeans(monkeypatch, tmp_path: Pa
     assert metadata["stability_mask_applied"] is True
     assert Path(artifacts.raster_path).exists()
     assert Path(metadata["downloaded_zone_raster"]).exists()
+    assert Path(artifacts.mean_ndvi_path).exists()
+    assert metadata["downloaded_mean_ndvi"] == artifacts.mean_ndvi_path
 
 
 def test_prepare_selected_period_artifacts_multiindex(monkeypatch, tmp_path: Path) -> None:
@@ -562,6 +568,8 @@ def test_prepare_selected_period_artifacts_multiindex(monkeypatch, tmp_path: Pat
     assert metadata["multiindex_sample_size"] == 1234
     assert Path(artifacts.raster_path).exists()
     assert Path(metadata["downloaded_zone_raster"]).exists()
+    assert Path(artifacts.mean_ndvi_path).exists()
+    assert metadata["downloaded_mean_ndvi"] == artifacts.mean_ndvi_path
 
 
 def test_cleanup_helper_rolls_back_min_mapping_unit(monkeypatch) -> None:
@@ -927,6 +935,7 @@ def test_export_selected_period_zones_returns_local_paths(monkeypatch, tmp_path:
 
     paths = result["paths"]
     assert Path(paths["raster"]).exists()
+    assert Path(paths["mean_ndvi"]).exists()
     assert Path(paths["vectors"]).exists()
     if paths["zonal_stats"] is not None:
         assert Path(paths["zonal_stats"]).exists()


### PR DESCRIPTION
### **User description**
## Summary
- add the mean NDVI raster path to `ZoneArtifacts`, ensure it is recorded by the zone builders, and surface it from the zone API response
- stage and expose the mean NDVI raster when preparing zone download bundles and remote exports
- extend the zone export tests to assert the mean NDVI raster is generated and distributed with the other artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e23a2c5b488327b15a673d021bce47


___

### **PR Type**
Enhancement


___

### **Description**
- Add mean NDVI raster path to ZoneArtifacts class

- Include mean NDVI files in zone export bundles

- Update export functions to handle mean NDVI artifacts

- Extend tests to verify mean NDVI artifact generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ZoneArtifacts"] --> B["Add mean_ndvi_path field"]
  B --> C["Export Functions"]
  C --> D["Include mean NDVI in downloads"]
  C --> E["Upload to cloud storage"]
  D --> F["Zone Export Bundle"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exports.py</strong><dd><code>Add mean NDVI to export workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/exports.py

<ul><li>Add mean NDVI file handling in <code>_download_zone_artifacts</code> function<br> <li> Include mean NDVI in file lists and path mappings for exports<br> <li> Update cloud storage and drive export functions to handle mean NDVI<br> <li> Add mean NDVI to zip export processing</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/141/files#diff-b58e5436743b0f53bc46154af4ec1a7ddaf5f13cbe9a90df7b87efdafa94fe4c">+16/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Extend ZoneArtifacts with mean NDVI support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Add <code>mean_ndvi_path</code> field to <code>ZoneArtifacts</code> dataclass<br> <li> Update <code>_assemble_zone_artifacts</code> function to accept mean NDVI path <br>parameter<br> <li> Pass mean NDVI path in zone artifact preparation functions<br> <li> Include mean NDVI path in API response paths</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/141/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_exports_registry.py</strong><dd><code>Add mean NDVI export tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_exports_registry.py

<ul><li>Create mean NDVI test raster in <code>_create_zone_artifacts</code> helper<br> <li> Add mean NDVI path to ZoneArtifacts test instances<br> <li> Assert mean NDVI files are included in export bundles<br> <li> Verify mean NDVI upload to cloud storage and signed URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/141/files#diff-3df5cf880bd9ca1623a8e6fb5c6be240bc60cd1427c8a76dcb5470c992383c5c">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_zones.py</strong><dd><code>Update zone tests for mean NDVI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones.py

<ul><li>Assert mean NDVI path exists in zone classification tests<br> <li> Add mean NDVI path to mock ZoneArtifacts instances<br> <li> Verify mean NDVI metadata in artifact preparation tests<br> <li> Check mean NDVI path in zone export result validation</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/141/files#diff-ca8cea705525d0ea55f6f1fdbb1c8b8ca6a132ee059d07ba59dceed9f2a6392e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

