### PR TITLE
Fix NDVI computation to use float bands and preserve mask

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -1045,7 +1045,9 @@ def _build_composite_series(
 
 
 def _compute_ndvi(image: ee.Image) -> ee.Image:
-    return image.normalizedDifference(["B8", "B4"]).rename("NDVI")
+    bands = image.select(["B8", "B4"]).toFloat()
+    ndvi = bands.normalizedDifference(["B8", "B4"]).rename("NDVI")
+    return ndvi.updateMask(image.mask())
 
 
 def _compute_ndre(image: ee.Image) -> ee.Image:


### PR DESCRIPTION
### **User description**
## Summary
- update the NDVI helper to select bands B8/B4, cast to float, and reapply the original mask after computing the normalized difference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24c7b2fc48327b41b992dc1dadeda


___

### **PR Type**
Bug fix


___

### **Description**
- Fix NDVI computation to cast bands to float

- Preserve original image mask after normalization

- Select specific bands B8/B4 before processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Image"] --> B["Select B8/B4 bands"]
  B --> C["Cast to Float"]
  C --> D["Compute NDVI"]
  D --> E["Apply Original Mask"]
  E --> F["Return Masked NDVI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Enhanced NDVI computation with float casting and mask preservation</code></dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Modified <code>_compute_ndvi</code> function to select bands B8/B4 explicitly<br> <li> Added float casting for proper numerical computation<br> <li> Preserved original image mask after NDVI calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/143/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

