### PR TITLE
Ensure NDVI output uses single-band mask

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -1047,7 +1047,8 @@ def _build_composite_series(
 def _compute_ndvi(image: ee.Image) -> ee.Image:
     bands = image.select(["B8", "B4"]).toFloat()
     ndvi = bands.normalizedDifference(["B8", "B4"]).rename("NDVI")
-    return ndvi.updateMask(image.mask())
+    valid_mask = bands.mask().reduce(ee.Reducer.min())
+    return ndvi.updateMask(valid_mask)
 
 
 def _compute_ndre(image: ee.Image) -> ee.Image:


### PR DESCRIPTION
### **User description**
## Summary
- derive a combined validity mask from the NDVI source bands
- apply the single-band mask to the NDVI image to keep band counts aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e25029bbd88327af642d07bac5a5c7


___

### **PR Type**
Bug fix


___

### **Description**
- Fix NDVI mask to use single-band validity mask

- Derive combined mask from source bands B8 and B4

- Apply minimum reducer to ensure proper band alignment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  bands["B8, B4 bands"] --> mask["bands.mask()"] --> reducer["ee.Reducer.min()"] --> validMask["valid_mask"] --> ndvi["NDVI with single-band mask"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Fix NDVI mask computation for band alignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Replace <code>image.mask()</code> with derived single-band mask<br> <li> Add <code>valid_mask</code> computation using <code>ee.Reducer.min()</code><br> <li> Ensure NDVI output maintains proper band count alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/145/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

