### PR TITLE
Preserve NDVI masks via shared temporal stats helper

### DIFF
--- a/services/backend/app/services/image_stats.py
+++ b/services/backend/app/services/image_stats.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence
+
+import ee
+
+
+def _prepare_collection(
+    collection: ee.ImageCollection | Sequence[ee.Image] | Iterable[ee.Image],
+    band_name: str,
+    rename_base: str,
+) -> ee.ImageCollection:
+    if hasattr(collection, "map"):
+        base = collection  # assume already an ImageCollection-like object
+    else:
+        base = ee.ImageCollection(collection)
+
+    def _select_band(image: ee.Image) -> ee.Image:
+        return ee.Image(image).select([band_name]).toFloat().rename(rename_base)
+
+    return base.map(_select_band)
+
+
+def temporal_stats(
+    collection: ee.ImageCollection | Sequence[ee.Image] | Iterable[ee.Image],
+    *,
+    band_name: str,
+    rename_prefix: str | None = None,
+    mean_band_name: str | None = None,
+) -> Mapping[str, ee.Image]:
+    """Compute temporal statistics for ``band_name`` while preserving masks."""
+
+    rename_base = rename_prefix or band_name
+    prepared = _prepare_collection(collection, band_name, rename_base)
+
+    raw_sum = prepared.reduce(ee.Reducer.sum())
+    raw_count = prepared.reduce(ee.Reducer.count())
+    raw_median = prepared.reduce(ee.Reducer.median())
+    raw_std = prepared.reduce(ee.Reducer.stdDev())
+
+    valid_mask = raw_count.gt(0)
+    safe_count = raw_count.where(raw_count.eq(0), 1)
+
+    mean_unmasked = raw_sum.divide(safe_count)
+    mean_name = mean_band_name or f"{rename_base}_mean"
+    mean = mean_unmasked.updateMask(valid_mask).rename(mean_name)
+
+    median = raw_median.updateMask(valid_mask).rename(f"{rename_base}_median")
+    std = raw_std.updateMask(valid_mask).rename(f"{rename_base}_stdDev")
+
+    epsilon = ee.Image.constant(1e-6)
+    mean_abs = mean_unmasked.abs()
+    safe_denominator = mean_abs.where(mean_abs.lt(epsilon), epsilon)
+    cv_raw = raw_std.divide(safe_denominator)
+    cv = cv_raw.where(mean_unmasked.lte(0), 0).updateMask(valid_mask).rename(
+        f"{rename_base}_cv"
+    )
+
+    return {
+        "collection": prepared,
+        "raw_sum": raw_sum,
+        "raw_count": raw_count,
+        "raw_median": raw_median,
+        "raw_std": raw_std,
+        "mean_unmasked": mean_unmasked,
+        "mean": mean,
+        "median": median,
+        "std": std,
+        "cv": cv,
+        "valid_mask": valid_mask,
+    }

--- a/services/backend/app/services/tiles.py
+++ b/services/backend/app/services/tiles.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping
 import ee
 from ee import ServiceAccountCredentials
 from app.services.gcs import download_json, exists
+from app.services.image_stats import temporal_stats
 from app.services.indices import IndexDefinition, resolve_index
 
 # Reuse the same SA method you used for NDVI
@@ -80,7 +81,13 @@ def _index_image_for_range(
         parameters=parameters,
         collection=collection,
     )
-    mean_img = ee.Image(coll.select(definition.band_name).mean())
+    stats = temporal_stats(
+        coll.select(definition.band_name),
+        band_name=definition.band_name,
+        rename_prefix=definition.band_name,
+        mean_band_name=definition.band_name,
+    )
+    mean_img = stats["mean"]
     img = mean_img.clip(geom)
     if definition.valid_range is not None:
         low, high = definition.valid_range

--- a/services/backend/tests/fake_ee.py
+++ b/services/backend/tests/fake_ee.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from math import sqrt
 from types import SimpleNamespace
 from typing import Any, Iterable
 
@@ -34,9 +35,24 @@ class FakeImage:
         log.setdefault("added_bands", []).append(getattr(band_image, "name", None))
         return self
 
-    def select(self, band: str):
+    def select(self, band: Any):
         log = self._context.setdefault("log", {})
-        log.setdefault("selected_bands", []).append(band)
+        if isinstance(band, (list, tuple)):
+            entry = band[0] if len(band) == 1 else tuple(band)
+        else:
+            entry = band
+        log.setdefault("selected_bands", []).append(entry)
+        return self
+
+    def toFloat(self):
+        log = self._context.setdefault("log", {})
+        log.setdefault("to_float_calls", 0)
+        log["to_float_calls"] += 1
+        return self
+
+    def rename(self, name: str):
+        log = self._context.setdefault("log", {})
+        log.setdefault("renamed_images", []).append(name)
         return self
 
 
@@ -48,6 +64,17 @@ class FakeMeanImage:
         self.requested_vis: dict[str, Any] | None = None
         self.download_args: dict[str, Any] | None = None
         self._context = context
+        self.name: str | None = None
+        self.mask: Any = None
+
+    def _wrap(self, value: float | None):
+        return FakeMeanImage(value, self._context)
+
+    @staticmethod
+    def _value_of(other: Any) -> float | None:
+        if isinstance(other, FakeMeanImage):
+            return other.value
+        return other
 
     def clip(self, geom: Any):
         self.clipped_geom = geom
@@ -66,6 +93,62 @@ class FakeMeanImage:
             self.value = high
         return self
 
+    def rename(self, name: str):
+        self.name = name
+        if self._context is not None:
+            log = self._context.setdefault("log", {})
+            log.setdefault("renamed_images", []).append(name)
+        return self
+
+    def updateMask(self, mask: Any):
+        self.mask = mask
+        if self._context is not None:
+            log = self._context.setdefault("log", {})
+            log.setdefault("update_masks", []).append(mask)
+        return self
+
+    def divide(self, other: Any):
+        other_value = self._value_of(other)
+        if other_value in (0, None) or self.value is None:
+            return self._wrap(None)
+        return self._wrap(self.value / other_value)
+
+    def where(self, condition: Any, substitute: Any):
+        cond_value = self._value_of(condition)
+        if cond_value:
+            sub_value = self._value_of(substitute)
+            return self._wrap(sub_value)
+        return self._wrap(self.value)
+
+    def gt(self, other: Any):
+        other_value = self._value_of(other)
+        if self.value is None or other_value is None:
+            return self._wrap(0)
+        return self._wrap(1 if self.value > other_value else 0)
+
+    def eq(self, other: Any):
+        other_value = self._value_of(other)
+        if self.value is None or other_value is None:
+            return self._wrap(0)
+        return self._wrap(1 if self.value == other_value else 0)
+
+    def lt(self, other: Any):
+        other_value = self._value_of(other)
+        if self.value is None or other_value is None:
+            return self._wrap(0)
+        return self._wrap(1 if self.value < other_value else 0)
+
+    def lte(self, other: Any):
+        other_value = self._value_of(other)
+        if self.value is None or other_value is None:
+            return self._wrap(0)
+        return self._wrap(1 if self.value <= other_value else 0)
+
+    def abs(self):
+        if self.value is None:
+            return self._wrap(None)
+        return self._wrap(abs(self.value))
+
     def getDownloadURL(self, params: dict[str, Any]):
         self.download_args = params
         if self._context is not None:
@@ -83,15 +166,23 @@ class FakeMeanImage:
 
 
 class FakeImageCollection:
-    def __init__(self, name: str, context: dict[str, Any]):
+    def __init__(
+        self,
+        name: str,
+        context: dict[str, Any],
+        images: Iterable[Any] | None = None,
+    ):
         self.name = name
         self.context = context
         self.geom: Any = None
         self.start: str | None = None
         self.end: str | None = None
         self.filters: list[Any] = []
-        values = context.get("values", [])
-        self.images = [FakeImage(val, context) for val in values]
+        if images is None:
+            values = context.get("values", [])
+            self.images = [FakeImage(val, context) for val in values]
+        else:
+            self.images = list(images)
         context.setdefault("log", {}).setdefault("collections", []).append(name)
 
     def filterBounds(self, geom: Any):
@@ -130,27 +221,115 @@ class FakeImageCollection:
         count = len(self.images)
         return SimpleNamespace(getInfo=lambda: count)
 
+    def reduce(self, reducer: Any):
+        kind = getattr(reducer, "kind", str(reducer))
+        log = self.context.setdefault("log", {})
+        log.setdefault("reduce_calls", []).append(kind)
+
+        def _value(item: Any) -> float | None:
+            if isinstance(item, FakeMeanImage):
+                return item.value
+            if hasattr(item, "index_value") and item.index_value is not None:
+                return item.index_value
+            return getattr(item, "_raw_value", None)
+
+        raw_values = [_value(img) for img in self.images]
+        values = [val for val in raw_values if val is not None]
+
+        if kind == "sum":
+            result = sum(values) if values else 0
+        elif kind == "count":
+            result = len(values)
+        elif kind == "mean":
+            result = sum(values) / len(values) if values else None
+        elif kind == "median":
+            if not values:
+                result = None
+            else:
+                ordered = sorted(values)
+                mid = len(ordered) // 2
+                if len(ordered) % 2:
+                    result = ordered[mid]
+                else:
+                    result = (ordered[mid - 1] + ordered[mid]) / 2
+        elif kind == "stdDev":
+            if not values:
+                result = 0
+            else:
+                mean_val = sum(values) / len(values)
+                variance = sum((val - mean_val) ** 2 for val in values) / len(values)
+                result = sqrt(variance)
+        else:
+            result = None
+
+        return FakeMeanImage(result, self.context)
+
 
 def setup_fake_ee(monkeypatch, module, values: Iterable[float]):
     context: dict[str, Any] = {"values": list(values), "log": {}}
 
-    def fake_image_collection(name: str):
+    def fake_image_collection(source: Any):
+        if isinstance(source, FakeImageCollection):
+            return source
+
         context_copy = {"values": list(context["values"]), "log": context["log"]}
-        return FakeImageCollection(name, context_copy)
+        if isinstance(source, (list, tuple)):
+            return FakeImageCollection("inline", context_copy, images=list(source))
+        return FakeImageCollection(source, context_copy)
 
-    fake_filter = SimpleNamespace(
-        lt=lambda *args, **kwargs: ("lt", args, kwargs),
-        calendarRange=lambda start, _end, _unit: start,
-    )
+    try:
+        from app.services import image_stats as image_stats_module  # noqa: WPS433
+    except Exception:  # pragma: no cover - defensive
+        image_stats_module = None
 
-    fake_ee = SimpleNamespace(
-        ImageCollection=fake_image_collection,
-        Geometry=lambda geom: geom,
-        Filter=fake_filter,
-        Image=lambda value: value,
-    )
+    modules: list[Any]
+    if isinstance(module, (list, tuple, set)):
+        modules = list(module)
+    else:
+        modules = [module]
 
-    monkeypatch.setattr(module, "ee", fake_ee)
+    if image_stats_module is not None and image_stats_module not in modules:
+        modules.append(image_stats_module)
+
+    def _make_fake_filter():
+        return SimpleNamespace(
+            lt=lambda *args, **kwargs: ("lt", args, kwargs),
+            calendarRange=lambda start, _end, _unit: start,
+        )
+
+    class FakeReducer:
+        def __init__(self, kind: str):
+            self.kind = kind
+
+    def _make_fake_reducer():
+        return SimpleNamespace(
+            sum=lambda: FakeReducer("sum"),
+            count=lambda: FakeReducer("count"),
+            median=lambda: FakeReducer("median"),
+            stdDev=lambda: FakeReducer("stdDev"),
+            mean=lambda: FakeReducer("mean"),
+        )
+
+    class FakeImageFactory:
+        def __init__(self, ctx: dict[str, Any]):
+            self._ctx = ctx
+
+        def __call__(self, value: Any):
+            return value
+
+        def constant(self, value: float):
+            return FakeMeanImage(value, self._ctx)
+
+    for target in modules:
+        fake_image = FakeImageFactory(context)
+        fake_ee = SimpleNamespace(
+            ImageCollection=fake_image_collection,
+            Geometry=lambda geom: geom,
+            Filter=_make_fake_filter(),
+            Reducer=_make_fake_reducer(),
+            Image=fake_image,
+        )
+        monkeypatch.setattr(target, "ee", fake_ee)
 
     return context
 

--- a/services/backend/tests/test_image_stats.py
+++ b/services/backend/tests/test_image_stats.py
@@ -1,0 +1,49 @@
+import math
+from pathlib import Path
+import sys
+
+import pytest
+
+TEST_DIR = Path(__file__).resolve().parent
+if str(TEST_DIR) not in sys.path:
+    sys.path.append(str(TEST_DIR))
+
+from fake_ee import FakeMeanImage, setup_fake_ee  # noqa: E402  pylint: disable=wrong-import-position
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.append(str(BACKEND_DIR))
+
+from app.services import image_stats  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_temporal_stats_uses_sum_and_count(monkeypatch):
+    context = setup_fake_ee(monkeypatch, image_stats, [0.2, 0.4, 0.6])
+
+    collection = image_stats.ee.ImageCollection("TEST_COLLECTION")
+    stats = image_stats.temporal_stats(
+        collection,
+        band_name="NDVI",
+        rename_prefix="NDVI",
+        mean_band_name="NDVI",
+    )
+
+    assert isinstance(stats["mean"], FakeMeanImage)
+    assert stats["mean"].name == "NDVI"
+    assert stats["mean"].value == pytest.approx(0.4)
+    assert stats["median"].name == "NDVI_median"
+    assert stats["median"].value == pytest.approx(0.4)
+    assert stats["std"].name == "NDVI_stdDev"
+    expected_std = math.sqrt(((0.2 - 0.4) ** 2 + (0.4 - 0.4) ** 2 + (0.6 - 0.4) ** 2) / 3)
+    assert stats["std"].value == pytest.approx(expected_std)
+    assert stats["cv"].name == "NDVI_cv"
+    assert stats["cv"].value == pytest.approx(expected_std / 0.4)
+
+    assert stats["raw_sum"].value == pytest.approx(1.2)
+    assert stats["raw_count"].value == 3
+    assert stats["valid_mask"].value == 1
+    assert isinstance(stats["mean"].mask, FakeMeanImage)
+    assert stats["mean"].mask.value == 1
+
+    reduce_calls = context["log"].get("reduce_calls", [])
+    assert reduce_calls == ["sum", "count", "median", "stdDev"]

--- a/services/backend/tests/test_tiles_indices.py
+++ b/services/backend/tests/test_tiles_indices.py
@@ -53,6 +53,12 @@ def test_gndvi_images_and_metadata(monkeypatch):
     assert month.clamped_to == (-1.0, 1.0)
     assert month.value == pytest.approx(1.0)
 
+    reduce_calls = context["log"].get("reduce_calls", [])
+    assert reduce_calls.count("sum") == 2
+    assert reduce_calls.count("count") == 2
+    assert reduce_calls.count("median") == 2
+    assert reduce_calls.count("stdDev") == 2
+
     tile = tiles.get_tile_template_for_image(month, definition=definition)
     assert tile["vis"]["bands"] == [definition.band_name]
     assert tile["vis"]["min"] == pytest.approx(definition.valid_range[0])


### PR DESCRIPTION
### **User description**
## Summary
- add a reusable `temporal_stats` helper that computes masked per-pixel statistics for NDVI and related indices
- update export, NDVI, tile, and zones code paths to use the helper so mean images preserve masks
- expand the fake Earth Engine test harness and add regression tests for the new sum/count behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e257aae92083279ca1a8efd8cfe765


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce reusable `temporal_stats` helper for masked statistics

- Update NDVI, export, tiles, and zones to preserve masks

- Expand fake Earth Engine test harness capabilities

- Add regression tests for sum/count behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["temporal_stats helper"] --> B["export.py"]
  A --> C["ndvi.py"]
  A --> D["tiles.py"]
  A --> E["zones.py"]
  F["fake_ee.py"] --> G["test coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>export.py</strong><dd><code>Replace mean() with temporal_stats helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-5e2d28a7e848b401191a00d5496480010316038f29a07a93e44dca190ef2a30b">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>image_stats.py</strong><dd><code>Add temporal statistics computation helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-a37883f914564597c75762935cd1653797a0f09da81ab8f15c9c2d52cb4fb5d8">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ndvi.py</strong><dd><code>Use temporal_stats for monthly computations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-575328b5308256d500163161a4554cbf71548780f404b514b787f4399e4b806a">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tiles.py</strong><dd><code>Replace mean() with temporal_stats helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-c420ded67b271247fc247ac9932da9692949bb7608835f8ce2e3e4dedd2499e6">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zones.py</strong><dd><code>Refactor NDVI stats using temporal_stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+11/-22</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>fake_ee.py</strong><dd><code>Enhance fake Earth Engine test harness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-eb1b84d2342d31c18533ac717a0072d28edfe1f9a93746877a15262b41e7d1ea">+200/-21</a></td>

</tr>

<tr>
  <td><strong>test_export_indices.py</strong><dd><code>Update tests for temporal_stats integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-4383466bb5c103d6b440bc045aaec5ec3d35dbe12506993b4d1ec33033360f0c">+6/-31</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_image_stats.py</strong><dd><code>Add tests for temporal_stats helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-0f440aa8f41c35f2193f2c820b53d79bc51421b52eeb8b7d810980aefe176d3b">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ndvi_monthly.py</strong><dd><code>Update monthly NDVI tests for refactoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-781429c2a0a35ab809e153171d398dcc19cc973c7219e468d9ca9bdff5c7d630">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tiles_indices.py</strong><dd><code>Update tile tests for temporal_stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/146/files#diff-eec5068cba517ece6f99ab3775a71491cc2d4c9e4f515f655f8b5ba0752e9034">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

