### PR TITLE
Improve NDVI mask fallback handling

### DIFF
--- a/services/backend/tests/test_zones.py
+++ b/services/backend/tests/test_zones.py
@@ -112,7 +112,8 @@ def test_compute_ndvi_preserves_source_mask() -> None:
 
     result = zones._compute_ndvi(fake_image)
 
-    assert fake_image.selected == [("B8", "B4")]
+    assert fake_image.selected[0] == ("B8", "B4")
+    assert "B8" in fake_image.selected
     assert fake_image.to_float_calls == 1
     assert fake_image.normalized_difference_calls == [("B8", "B4")]
     assert fake_image.mask_called is True


### PR DESCRIPTION
### **User description**
## Summary
- build NDVI masks using the B8 band when present and fall back to a collapsed image mask when needed
- update the NDVI unit test to reflect the additional B8 band selection during mask construction

## Testing
- pytest tests/test_zones.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e317d7a3a08327bc0709b2c8cdce2d


___

### **PR Type**
Enhancement


___

### **Description**
- Improve NDVI mask selection with B8 band fallback

- Add defensive error handling for Earth Engine operations

- Update unit test to verify B8 band selection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check B8 band availability"] --> B["B8 available?"]
  B -->|Yes| C["Use B8 mask"]
  B -->|No| D["Use fallback mask"]
  C --> E["Apply mask to NDVI"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Enhanced NDVI mask selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Enhanced <code>_compute_ndvi</code> function with intelligent mask selection<br> <li> Added B8 band availability check with error handling<br> <li> Implemented fallback to reduced image mask when B8 unavailable<br> <li> Added defensive guards for Earth Engine API calls</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/149/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+31/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_zones.py</strong><dd><code>Updated NDVI unit test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones.py

<ul><li>Updated NDVI test to verify B8 band selection<br> <li> Modified assertion to check for B8 in selected bands</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/149/files#diff-ca8cea705525d0ea55f6f1fdbb1c8b8ca6a132ee059d07ba59dceed9f2a6392e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

