### PR TITLE
Retain low NDVI pixels in zone pipeline

### DIFF
--- a/services/backend/app/services/zones.py
+++ b/services/backend/app/services/zones.py
@@ -1089,7 +1089,7 @@ def _compute_ndvi(image: ee.Image) -> ee.Image:
     bands = base.select(["B8", "B4"]).toFloat()
     ndvi = bands.normalizedDifference(["B8", "B4"]).rename("NDVI").toFloat()
 
-    ndvi_range_mask = ndvi.gt(0).And(ndvi.lt(1))
+    ndvi_range_mask = ndvi.lt(1)
 
     source_mask = bands.mask()
     combined_mask = ndvi_range_mask
@@ -1099,11 +1099,12 @@ def _compute_ndvi(image: ee.Image) -> ee.Image:
             try:
                 mask_image = mask_image.reduce(ee.Reducer.min())
             except Exception:  # pragma: no cover - defensive guard for fake EE objects
-                mask_image = mask_image
+                pass
         if hasattr(mask_image, "rename"):
             mask_image = mask_image.rename("mask")
         if hasattr(mask_image, "gt"):
             mask_image = mask_image.gt(0)
+
         if hasattr(mask_image, "And"):
             combined_mask = mask_image.And(ndvi_range_mask)
         elif hasattr(ndvi_range_mask, "And"):


### PR DESCRIPTION
### **User description**
## Summary
- allow the NDVI mask to retain pixels with zero or negative values instead of discarding them
- keep the source cloud/shadow mask while combining it with the relaxed NDVI range check
- update the NDVI masking unit test to assert the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e339ebdd148327b6b98479f76b83ea


___

### **PR Type**
Enhancement


___

### **Description**
- Modify NDVI mask to retain zero/negative pixels

- Preserve source cloud/shadow mask in combination

- Update unit tests for new masking behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NDVI Calculation"] --> B["Old: gt(0).And(lt(1))"]
  A --> C["New: lt(1) only"]
  D["Source Mask"] --> E["Combined with NDVI mask"]
  C --> E
  E --> F["Preserve non-vegetated pixels"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zones.py</strong><dd><code>Relax NDVI masking to retain low values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/app/services/zones.py

<ul><li>Remove lower bound check from NDVI range mask (<code>gt(0)</code>)<br> <li> Keep upper bound check (<code>lt(1)</code>) to filter invalid values<br> <li> Clean up exception handling with <code>pass</code> statement<br> <li> Add whitespace for code formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/155/files#diff-4b4e05308109dca9d88bee6ccf375beadd89750e656005ccfd25f54459fb27c7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_zones.py</strong><dd><code>Update NDVI masking unit test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/backend/tests/test_zones.py

<ul><li>Remove <code>FakeCombinedMask</code> class and simplify test structure<br> <li> Update <code>FakeCondition.And()</code> to return modified condition object<br> <li> Adjust test assertions to verify no <code>gt(0)</code> calls on NDVI<br> <li> Verify only <code>lt(1)</code> filtering is applied to NDVI values</ul>


</details>


  </td>
  <td><a href="https://github.com/shaunmcn2001/vision_backend/pull/155/files#diff-ca8cea705525d0ea55f6f1fdbb1c8b8ca6a132ee059d07ba59dceed9f2a6392e">+6/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

