### PR TITLE
Pin Pydantic to the v1 series for root validator compatibility

### DIFF
--- a/services/backend/requirements.txt
+++ b/services/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-pydantic
+pydantic<2
 pydantic-settings
 earthengine-api
 numpy


### PR DESCRIPTION
## Summary
- pin the backend service's Pydantic dependency below v2 so existing root validators keep working during deploys

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e39853832c83278d9f950b978560a6