### PR TITLE
feat: guard rails and diagnostics plumbing for zone exports

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,7 @@
+## Surgical edit policy
+- Anchor-based edits only; abort if anchors missing.
+
+## Diagnostics export
+- The /zones/production endpoint accepts `diagnostics=true`.
+- When enabled, service returns diagnostics in JSON and also writes `diagnostics/diagnostics.json` inside the export ZIP.
+- Error codes: E_INPUT_AOI, E_NO_MONTHS, E_FIRST_MONTH_EMPTY, E_MEAN_EMPTY, E_MEAN_CONSTANT, E_STABILITY_EMPTY, E_BREAKS_COLLAPSED, E_FEW_CLASSES, E_VECT_EMPTY, E_EXPORT_FAIL_*.

--- a/services/backend/app/api/zones.py
+++ b/services/backend/app/api/zones.py
@@ -290,10 +290,10 @@ def create_production_zones(
         )
     except PipelineError as exc:
         logger.warning(
-            "Pipeline error for AOI %s (target %s): %s",
+            "Pipeline error: %s (aoi=%s target=%s)",
+            exc,
             request.aoi_name,
             request.export_target,
-            exc,
             exc_info=True,
         )
         raise HTTPException(
@@ -323,6 +323,9 @@ def create_production_zones(
         )
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+    diagnostics_payload = result.get("diagnostics") if diagnostics else None
+    if diagnostics_payload is not None:
+        result.pop("diagnostics", None)
     result.pop("artifacts", None)
     metadata = result.get("metadata", {}) or {}
     used_months: List[str] = metadata.get("used_months") or request.months
@@ -346,6 +349,9 @@ def create_production_zones(
         "tasks": result.get("tasks", {}),
         "metadata": metadata,
     }
+
+    if diagnostics and diagnostics_payload is not None:
+        response["diagnostics"] = diagnostics_payload
 
     if palette is not None:
         response["palette"] = palette

--- a/services/backend/app/utils/logging_colors.py
+++ b/services/backend/app/utils/logging_colors.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import logging
+import os
+
+# Simple ANSI color codes; auto-disable on non-TTY/CI
+USE_COLOR = os.getenv("LOG_COLOR", "1") == "1" and os.getenv("NO_COLOR") is None
+
+COLORS = {
+    "RESET": "\033[0m",
+    "GRAY": "\033[90m",
+    "RED": "\033[91m",
+    "GREEN": "\033[92m",
+    "YELLOW": "\033[93m",
+    "BLUE": "\033[94m",
+    "MAGENTA": "\033[95m",
+    "CYAN": "\033[96m",
+}
+
+LEVEL_COLOR = {
+    logging.DEBUG: "GRAY",
+    logging.INFO: "CYAN",
+    logging.WARNING: "YELLOW",
+    logging.ERROR: "RED",
+    logging.CRITICAL: "MAGENTA",
+}
+
+
+class ColorFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        msg = super().format(record)
+        if not USE_COLOR:
+            return msg
+        color = COLORS.get(LEVEL_COLOR.get(record.levelno, "RESET"), "")
+        reset = COLORS["RESET"]
+        return f"{color}{msg}{reset}"
+
+
+def install_color_handler(logger: logging.Logger, level: int = logging.INFO) -> None:
+    if any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        return
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
+    fmt = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+    handler.setFormatter(ColorFormatter(fmt))
+    logger.addHandler(handler)
+    logger.setLevel(level)

--- a/services/backend/tests/test_zones_diagnostics.py
+++ b/services/backend/tests/test_zones_diagnostics.py
@@ -1,0 +1,64 @@
+import pytest
+
+from app.api import zones as zones_api
+from app.api.zones import ProductionZonesRequest
+
+
+@pytest.fixture
+def sample_aoi():
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [149.0, -35.0],
+                [149.0005, -35.0],
+                [149.0005, -35.0005],
+                [149.0, -35.0005],
+                [149.0, -35.0],
+            ]
+        ],
+    }
+
+
+def test_diagnostics_toggle(monkeypatch, sample_aoi):
+    captured = {}
+
+    def fake_export(*args, diagnostics=False, **kwargs):
+        captured["diagnostics"] = diagnostics
+        base_payload = {
+            "paths": {},
+            "tasks": {},
+            "metadata": {"used_months": ["2025-07"], "skipped_months": []},
+        }
+        if diagnostics:
+            base_payload["diagnostics"] = {"stages": {"inputs": {"area_m2": 123}}}
+        return base_payload
+
+    monkeypatch.setattr(
+        zones_api.zone_service,
+        "export_selected_period_zones",
+        fake_export,
+    )
+
+    request = ProductionZonesRequest(
+        aoi_geojson=sample_aoi,
+        aoi_name="TEST",
+        method="ndvi_percentiles",
+        months=["2025-07", "2025-08"],
+        cloud_prob_max=60,
+        n_classes=5,
+        cv_mask_threshold=0.30,
+        mmu_ha=1.0,
+        smooth_radius_m=20,
+        open_radius_m=20,
+        close_radius_m=30,
+        simplify_tol_m=0.0,
+        simplify_buffer_m=0.0,
+        export_target="zip",
+        include_zonal_stats=True,
+    )
+
+    response = zones_api.create_production_zones(request, diagnostics=True)
+    assert captured.get("diagnostics") is True
+    assert "diagnostics" in response
+    assert "stages" in response["diagnostics"]


### PR DESCRIPTION
## Summary
- add colorized logging helper and wire guard-based diagnostics across zone service stages
- surface diagnostics payloads via the zones API and include diagnostics.json in exported ZIP bundles
- add regression coverage for diagnostics toggle behaviour and document new surgical editing guidance

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e4de7d75988327889b9541f2249714