### PR TITLE
fix: harden NDVI k-means guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,10 @@ for the period.
 - **E_MASK_SHAPE**: NDVI mask must be single-band. Use the intersection of `B8` and `B4` masks.
 - **E_COVERAGE_LOW**: Too few valid pixels before stability masking. Inspect diagnostics for `per_month_preview`/`mask_tiers` and widen the month window if needed.
 - **Coverage**: To improve coverage, expand the month range, relax SCL filters to include classes 3/7, raise `cloud_prob_max` into the 60–70 range, or temporarily disable the stability mask to gauge impact.
-- **E_RANGE_EMPTY**: NDVI_min == NDVI_max (no dynamic range). Check NDVI bands/float math; relax masks; verify AOI intersects imagery.
+- **E_RANGE_EMPTY**: NDVI_min == NDVI_max before classification. Fix by:
+  - Ensuring NDVI uses B8/B4 float math (no visualize, no integer rounding).
+  - Relaxing SCL/cloud masks (e.g., include classes 3/7) and/or widening months to include a greener + drier period.
+  - Verifying AOI intersects Sentinel-2 coverage and reduction region uses `buffer(5).bounds(1)` with `scale=10, bestEffort, tileScale=4`.
 - **E_BREAKS_COLLAPSED** (percentiles only): NDVI spread too small for distinct thresholds. Use `method=ndvi_kmeans` or widen the date range.
 
 ### Export package layout

--- a/services/backend/tests/test_ndvi_range_guard.py
+++ b/services/backend/tests/test_ndvi_range_guard.py
@@ -1,0 +1,48 @@
+import pytest
+
+pytest.importorskip("httpx", reason="httpx is required for FastAPI TestClient")
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def square_aoi() -> dict:
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-0.0005, -0.0005],
+                [-0.0005, 0.0005],
+                [0.0005, 0.0005],
+                [0.0005, -0.0005],
+                [-0.0005, -0.0005],
+            ]
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "months",
+    [["2025-07", "2025-08"]],
+)
+def test_ndvi_range_guard_present(client, square_aoi, months):
+    payload = {
+        "aoi_geojson": square_aoi,
+        "aoi_name": "RANGE_GUARD",
+        "months": months,
+        "method": "ndvi_kmeans",
+        "n_classes": 4,
+        "export_target": "zip",
+        "include_zonal_stats": False,
+    }
+    response = client.post("/zones/production?diagnostics=true", json=payload)
+    assert response.status_code in (200, 422)
+    diagnostics = response.json().get("diagnostics", {}).get("stages", {})
+    assert "ndvi_input_health" in diagnostics


### PR DESCRIPTION
## Summary
- tighten the monthly NDVI composites to keep a single float NDVI band and emit per-month spread diagnostics
- guard the k-means path with band/mask/coverage/range checks while jittering the NDVI input to preserve variability
- document E_RANGE_EMPTY remediation steps and add a regression test ensuring the NDVI input diagnostics stage runs

## Testing
- pytest tests/test_ndvi_range_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68e64f5a5ba88327801e1a1ea324df46